### PR TITLE
Feature/storage relations hasmany

### DIFF
--- a/Sources/UDFMacros/StorageRelationships.swift
+++ b/Sources/UDFMacros/StorageRelationships.swift
@@ -10,8 +10,8 @@ public enum RelationshipDescriptor {
 /// Attaches one or more storage relationships to an `@Storage`-annotated `Reducible`.
 ///
 /// Must be combined with `@Storage(_:)` on the same declaration — `@StorageRelationships`
-/// generates the relationship dictionaries and a `reduceRelationships(_:)` method, but
-/// it's `@Storage`'s generated `reduce(_:)` that actually calls `reduceRelationships`.
+/// generates the relationship dictionaries and a `_reduceRelationships(_:)` method, but
+/// it's `@Storage`'s generated `reduce(_:)` that actually calls `_reduceRelationships`.
 /// Using `@StorageRelationships` without `@Storage` is a compile-time error.
 ///
 ///     @Storage(Restaurant.self)
@@ -25,14 +25,14 @@ public enum RelationshipDescriptor {
 ///
 /// Generates, per `.hasOne` relationship:
 /// - `var by<Parent>Id: [Parent.ID: Item.ID] = [:]`
-/// - a `reduceRelationships(_:)` case for `Actions.DidLoadNestedItem<Parent.ID, Item>`
+/// - a `_reduceRelationships(_:)` case for `Actions.DidLoadNestedItem<Parent.ID, Item>`
 /// - an accessor overload `<item>By(<label>: Parent.ID) -> Item.ID?`
 ///
 /// Generates, per `.hasMany` relationship:
 /// - `var by<Parent>Id: [Parent.ID: OrderedSet<Item.ID>] = [:]` — same naming
 ///   scheme as `.hasOne` (no pluralization on the property: the key is still a
 ///   single `Parent.ID`, only the *value* is a collection)
-/// - three `reduceRelationships(_:)` cases, all additive via `.append`:
+/// - three `_reduceRelationships(_:)` cases, all additive via `.append`:
 ///   `Actions.DidLoadNestedItem<Parent.ID, Item>`,
 ///   `Actions.DidLoadNestedItems<Parent.ID, Item>`, and
 ///   `Actions.DidLoadNestedByParents<Parent.ID, Item>`
@@ -54,6 +54,12 @@ public enum RelationshipDescriptor {
 /// diverges here — `by<Parent>Id` is a strict convention, but argument labels
 /// (`review`, `fortuneResult`, `dishID`) are hand-picked for readability, not a
 /// mechanical function of the type name.
+///
+/// The `_reduceRelationships` / `_` prefix marks it as a generated, reserved
+/// member — matching the convention already used elsewhere in this codebase
+/// for internal/framework-generated members (e.g. `_OnContainerDidLoad`,
+/// `_BindableAction`). It signals "generated, don't hand-write a method with
+/// this exact name" the same way those do.
 ///
 /// Bundling relationships into one variadic call (rather than repeating
 /// `@StorageRelationship(...)` per relationship) is deliberate: only within a

--- a/Sources/UDFMacros/StorageRelationships.swift
+++ b/Sources/UDFMacros/StorageRelationships.swift
@@ -1,0 +1,53 @@
+/// Compile-time-only descriptor. Never constructed or evaluated at runtime —
+/// `StorageRelationshipsMacro` parses the *syntax* of each `.hasOne` argument
+/// directly from the attribute's argument list. This type exists solely so
+/// the `@StorageRelationships(...)` call type-checks before expansion runs.
+///
+/// `.hasMany` is intentionally not implemented yet — using it is a compile-time
+/// macro error, not silently-wrong generated code.
+public enum RelationshipDescriptor {
+    case hasOne(Any.Type, name: String? = nil, label: String? = nil)
+    case hasMany(Any.Type, name: String? = nil, label: String? = nil)
+}
+
+/// Attaches one or more storage relationships to an `@Storage`-annotated `Reducible`.
+///
+/// Must be combined with `@Storage(_:)` on the same declaration — `@StorageRelationships`
+/// generates the relationship dictionaries and a `reduceRelationships(_:)` method, but
+/// it's `@Storage`'s generated `reduce(_:)` that actually calls `reduceRelationships`.
+/// Using `@StorageRelationships` without `@Storage` is a compile-time error.
+///
+///     @Storage(Restaurant.self)
+///     @StorageRelationships(
+///         .hasOne(Review.self),                                    // -> byReviewId
+///         .hasOne(FortuneWheelResult.self, label: "fortuneResult"), // matches existing style
+///         .hasOne(Dish.self, label: "dishID")                       // matches existing style
+///     )
+///     struct AllRestaurants: Reducible { }
+///
+/// Generates, per relationship:
+/// - `var by<Parent>Id: [Parent.ID: Item.ID] = [:]`
+/// - a `reduceRelationships(_:)` case for `Actions.DidLoadNestedItem<Parent.ID, Item>`
+/// - an accessor overload `<item>By(<label>: Parent.ID) -> Item.ID?`
+///
+/// Bulk "load nested items grouped by parent" is deliberately **not** generated.
+/// The action used for that in this codebase (`DidLoadNestedItemByParents`) is
+/// defined at the app level, not in UDFMacros/UDF — its name and shape aren't
+/// standardized across apps, so the macro can't safely reference it. Add that
+/// case by hand in `reduceCustom(_:)` if a relationship needs it; it still has
+/// access to `byId` / `by<Parent>Id`.
+///
+/// `name:` overrides the storage property; `label:` overrides only the accessor's
+/// argument label. They're independent because the existing codebase already
+/// diverges here — `by<Parent>Id` is a strict convention, but argument labels
+/// (`review`, `fortuneResult`, `dishID`) are hand-picked for readability, not a
+/// mechanical function of the type name.
+///
+/// Bundling relationships into one variadic call (rather than repeating
+/// `@StorageRelationship(...)` per relationship) is deliberate: only within a
+/// single macro expansion can name collisions between two relationships to the
+/// same parent type be caught as a clear diagnostic instead of a silent
+/// duplicate/overwrite.
+@attached(member, names: arbitrary)
+public macro StorageRelationships(_ relationships: RelationshipDescriptor...) =
+    #externalMacro(module: "UDFMacrosMacros", type: "StorageRelationshipsMacro")

--- a/Sources/UDFMacros/StorageRelationships.swift
+++ b/Sources/UDFMacros/StorageRelationships.swift
@@ -1,10 +1,7 @@
 /// Compile-time-only descriptor. Never constructed or evaluated at runtime —
-/// `StorageRelationshipsMacro` parses the *syntax* of each `.hasOne` argument
-/// directly from the attribute's argument list. This type exists solely so
-/// the `@StorageRelationships(...)` call type-checks before expansion runs.
-///
-/// `.hasMany` is intentionally not implemented yet — using it is a compile-time
-/// macro error, not silently-wrong generated code.
+/// `StorageRelationshipsMacro` parses the *syntax* of each `.hasOne`/`.hasMany`
+/// argument directly from the attribute's argument list. This type exists solely
+/// so the `@StorageRelationships(...)` call type-checks before expansion runs.
 public enum RelationshipDescriptor {
     case hasOne(Any.Type, name: String? = nil, label: String? = nil)
     case hasMany(Any.Type, name: String? = nil, label: String? = nil)
@@ -21,21 +18,36 @@ public enum RelationshipDescriptor {
 ///     @StorageRelationships(
 ///         .hasOne(Review.self),                                    // -> byReviewId
 ///         .hasOne(FortuneWheelResult.self, label: "fortuneResult"), // matches existing style
-///         .hasOne(Dish.self, label: "dishID")                       // matches existing style
+///         .hasOne(Dish.self, label: "dishID"),                      // matches existing style
+///         .hasMany(Category.self)                                  // -> byCategoryId
 ///     )
 ///     struct AllRestaurants: Reducible { }
 ///
-/// Generates, per relationship:
+/// Generates, per `.hasOne` relationship:
 /// - `var by<Parent>Id: [Parent.ID: Item.ID] = [:]`
 /// - a `reduceRelationships(_:)` case for `Actions.DidLoadNestedItem<Parent.ID, Item>`
 /// - an accessor overload `<item>By(<label>: Parent.ID) -> Item.ID?`
 ///
-/// Bulk "load nested items grouped by parent" is deliberately **not** generated.
-/// The action used for that in this codebase (`DidLoadNestedItemByParents`) is
-/// defined at the app level, not in UDFMacros/UDF — its name and shape aren't
-/// standardized across apps, so the macro can't safely reference it. Add that
-/// case by hand in `reduceCustom(_:)` if a relationship needs it; it still has
-/// access to `byId` / `by<Parent>Id`.
+/// Generates, per `.hasMany` relationship:
+/// - `var by<Parent>Id: [Parent.ID: OrderedSet<Item.ID>] = [:]` — same naming
+///   scheme as `.hasOne` (no pluralization on the property: the key is still a
+///   single `Parent.ID`, only the *value* is a collection)
+/// - three `reduceRelationships(_:)` cases, all additive via `.append`:
+///   `Actions.DidLoadNestedItem<Parent.ID, Item>`,
+///   `Actions.DidLoadNestedItems<Parent.ID, Item>`, and
+///   `Actions.DidLoadNestedByParents<Parent.ID, Item>`
+/// - a pluralized accessor overload `<item>sBy(<label>: Parent.ID) -> [Item.ID]`
+///
+/// For `.hasOne`, bulk "load nested items grouped by parent" is deliberately
+/// **not** generated. The single-item case (`DidLoadNestedItem`) is the only
+/// realistic load pattern for a one-to-one relationship in this codebase; if a
+/// `.hasOne` relationship ever needs bulk loading, add that case by hand in
+/// `reduceCustom(_:)` — it still has access to `byId` / `by<Parent>Id`.
+///
+/// For `.hasMany`, bulk loading (`DidLoadNestedByParents`) *is* generated,
+/// since batch-loading children for several parents at once is the common case
+/// for one-to-many relationships (e.g. loading a page of parents and their
+/// children in one response).
 ///
 /// `name:` overrides the storage property; `label:` overrides only the accessor's
 /// argument label. They're independent because the existing codebase already
@@ -47,7 +59,9 @@ public enum RelationshipDescriptor {
 /// `@StorageRelationship(...)` per relationship) is deliberate: only within a
 /// single macro expansion can name collisions between two relationships to the
 /// same parent type be caught as a clear diagnostic instead of a silent
-/// duplicate/overwrite.
+/// duplicate/overwrite — this applies across `.hasOne` and `.hasMany` alike,
+/// since two relationships to the same parent type generate the same
+/// `Actions.DidLoadNestedItem<Parent.ID, _>` case regardless of kind.
 @attached(member, names: arbitrary)
 public macro StorageRelationships(_ relationships: RelationshipDescriptor...) =
     #externalMacro(module: "UDFMacrosMacros", type: "StorageRelationshipsMacro")

--- a/Sources/UDFMacros/StorageRelationships.swift
+++ b/Sources/UDFMacros/StorageRelationships.swift
@@ -13,8 +13,8 @@ public enum RelationshipDescriptor {
 /// Attaches one or more storage relationships to an `@Storage`-annotated `Reducible`.
 ///
 /// Must be combined with `@Storage(_:)` on the same declaration — `@StorageRelationships`
-/// generates the relationship dictionaries and a `reduceRelationships(_:)` method, but
-/// it's `@Storage`'s generated `reduce(_:)` that actually calls `reduceRelationships`.
+/// generates the relationship dictionaries and a `_reduceRelationships(_:)` method, but
+/// it's `@Storage`'s generated `reduce(_:)` that actually calls `_reduceRelationships`.
 /// Using `@StorageRelationships` without `@Storage` is a compile-time error.
 ///
 ///     @Storage(Restaurant.self)
@@ -27,7 +27,7 @@ public enum RelationshipDescriptor {
 ///
 /// Generates, per relationship:
 /// - `var by<Parent>Id: [Parent.ID: Item.ID] = [:]`
-/// - a `reduceRelationships(_:)` case for `Actions.DidLoadNestedItem<Parent.ID, Item>`
+/// - a `_reduceRelationships(_:)` case for `Actions.DidLoadNestedItem<Parent.ID, Item>`
 /// - an accessor overload `<item>By(<label>: Parent.ID) -> Item.ID?`
 ///
 /// Bulk "load nested items grouped by parent" is deliberately **not** generated.

--- a/Sources/UDFMacros/UDFMacros.swift
+++ b/Sources/UDFMacros/UDFMacros.swift
@@ -26,9 +26,15 @@ public macro SensitiveData(option: SensitiveDataOption? = nil) = #externalMacro(
 ///
 /// If `byId`, `reduce`, and/or the accessor are already declared in the
 /// attached struct, the macro leaves that member alone and only fills in
-/// what's missing — this is the escape hatch for a storage that needs an
-/// extra action case (e.g. `DidToggleFavorite<Movie>`) alongside the
-/// standard four: write your own `reduce` with the extra case, and the
-/// macro won't try to generate a conflicting one.
+/// what's missing.
+///
+/// **Custom actions:** if you declare a `mutating func reduceCustom(_ action:
+/// some Action)`, the generated `reduce`'s `default:` case calls it instead
+/// of `break` — write your bespoke cases there (e.g. `DidLoadPopularDishes`,
+/// `DidDislikeDish`) without needing to hand-write the whole `reduce`.
+/// If you don't declare `reduceCustom`, `default:` stays `break` exactly as
+/// before. For the rarer case where you need to override one of the
+/// standard four cases itself, write the full `reduce` by hand — the macro
+/// detects that and won't generate a conflicting one.
 @attached(member, names: named(byId), named(reduce), arbitrary)
 public macro Storage<Item: Identifiable>(_ type: Item.Type) = #externalMacro(module: "UDFMacrosMacros", type: "StorageMacro")

--- a/Sources/UDFMacros/UDFMacros.swift
+++ b/Sources/UDFMacros/UDFMacros.swift
@@ -10,5 +10,25 @@ public macro AutoHashable() = #externalMacro(module: "UDFMacrosMacros", type: "A
 @attached(peer)
 public macro SensitiveField() = #externalMacro(module: "UDFMacrosMacros", type: "SensitiveFieldMacro")
 
-@attached(extension, conformances: CustomStringConvertible, SensitiveDataRepresentable,  names: named(description), named(maskedDescription), named(plainDescription))
+@attached(extension, conformances: CustomStringConvertible, SensitiveDataRepresentable, names: named(description), named(maskedDescription), named(plainDescription))
 public macro SensitiveData(option: SensitiveDataOption? = nil) = #externalMacro(module: "UDFMacrosMacros", type: "SensitiveDataMacro")
+
+/// Generates the `byId` storage dictionary, the standard CRUD `reduce`
+/// handling (`DidLoadItems`, `DidLoadItem`, `DidUpdateItem`, `DeleteItem`),
+/// and a `<lowerCamelCase(Item)>By(id:)` convenience accessor (e.g. `dishBy(id:)`
+/// for `Dish`) that most `Reducible` "AllX" storages repeat verbatim.
+///
+/// The accessor falls back to `Item.empty` — the attached `Item` type must
+/// declare a static `empty` member itself (there's no protocol backing this
+/// in the codebase, so it isn't enforced at the `@Storage` declaration; a
+/// missing `.empty` surfaces as a compile error inside the generated
+/// accessor instead).
+///
+/// If `byId`, `reduce`, and/or the accessor are already declared in the
+/// attached struct, the macro leaves that member alone and only fills in
+/// what's missing — this is the escape hatch for a storage that needs an
+/// extra action case (e.g. `DidToggleFavorite<Movie>`) alongside the
+/// standard four: write your own `reduce` with the extra case, and the
+/// macro won't try to generate a conflicting one.
+@attached(member, names: named(byId), named(reduce), arbitrary)
+public macro Storage<Item: Identifiable>(_ type: Item.Type) = #externalMacro(module: "UDFMacrosMacros", type: "StorageMacro")

--- a/Sources/UDFMacrosMacros/DiagnosticMessage/StorageDiagnostic.swift
+++ b/Sources/UDFMacrosMacros/DiagnosticMessage/StorageDiagnostic.swift
@@ -1,0 +1,36 @@
+//
+//  StorageDiagnostic.swift
+//  UDFMacros
+//
+//  Created by Oleksandr Bodnar on 28.07.2026.
+//
+
+import SwiftDiagnostics
+import SwiftSyntax
+
+public enum StorageDiagnostic: DiagnosticMessage {
+    case unsupportedType
+    case invalidArgument
+
+    public var severity: DiagnosticSeverity {
+        .error
+    }
+
+    public var message: String {
+        switch self {
+        case .unsupportedType:
+            return "@Storage can only be applied to a 'struct' declaration"
+        case .invalidArgument:
+            return "@Storage requires a single argument in the form 'TypeName.self'"
+        }
+    }
+
+    public var diagnosticID: MessageID {
+        switch self {
+        case .unsupportedType:
+            return MessageID(domain: "StorageMacro", id: "unsupportedType")
+        case .invalidArgument:
+            return MessageID(domain: "StorageMacro", id: "invalidArgument")
+        }
+    }
+}

--- a/Sources/UDFMacrosMacros/DiagnosticMessage/StorageRelationshipsDiagnostic.swift
+++ b/Sources/UDFMacrosMacros/DiagnosticMessage/StorageRelationshipsDiagnostic.swift
@@ -23,7 +23,7 @@ public enum StorageRelationshipsDiagnostic: DiagnosticMessage {
         switch self {
         case .requiresStorage:
             return "@StorageRelationships requires @Storage(_:) on the same declaration — "
-                + "without it, the generated reduceRelationships(_:) is never called."
+                + "without it, the generated _reduceRelationships(_:) is never called."
         case let .duplicateName(name):
             return "Relationship name '\(name)' is used more than once. Pass an explicit "
                 + "`name:` to disambiguate two relationships to the same parent type."
@@ -31,7 +31,7 @@ public enum StorageRelationshipsDiagnostic: DiagnosticMessage {
             return "'\(typeName)' is already used as a relationship parent type on this "
                 + "declaration. Two relationships to the same parent type — regardless of "
                 + "whether they're `.hasOne` or `.hasMany` — would generate a duplicate "
-                + "`Actions.DidLoadNestedItem<\(typeName).ID, _>` case in reduceRelationships(_:), "
+                + "`Actions.DidLoadNestedItem<\(typeName).ID, _>` case in _reduceRelationships(_:), "
                 + "even if their storage property names differ via `name:`."
         case let .alreadyDeclared(name):
             return "'\(name)' is already declared manually. @StorageRelationships will not "

--- a/Sources/UDFMacrosMacros/DiagnosticMessage/StorageRelationshipsDiagnostic.swift
+++ b/Sources/UDFMacrosMacros/DiagnosticMessage/StorageRelationshipsDiagnostic.swift
@@ -1,0 +1,56 @@
+//
+//  StorageRelationshipsDiagnostic.swift
+//  UDFMacros
+//
+//  Created by Oleksandr Bodnar on 29.07.2026.
+//
+
+import SwiftDiagnostics
+import SwiftSyntax
+
+public enum StorageRelationshipsDiagnostic: DiagnosticMessage {
+    case requiresStorage
+    case duplicateName(String)
+    case alreadyDeclared(String)
+    case malformedArgument
+    case hasManyNotYetSupported
+
+    public var severity: DiagnosticSeverity {
+        .error
+    }
+
+    public var message: String {
+        switch self {
+        case .requiresStorage:
+            return "@StorageRelationships requires @Storage(_:) on the same declaration — "
+                + "without it, the generated reduceRelationships(_:) is never called."
+        case let .duplicateName(name):
+            return "Relationship name '\(name)' is used more than once. Pass an explicit "
+                + "`name:` to disambiguate two relationships to the same parent type."
+        case let .alreadyDeclared(name):
+            return "'\(name)' is already declared manually. @StorageRelationships will not "
+                + "overwrite it — remove the corresponding relationship from "
+                + "@StorageRelationships if this is intentional."
+        case .malformedArgument:
+            return "Expected `.hasOne(Type.self)`, optionally with `name:` and/or `label:`."
+        case .hasManyNotYetSupported:
+            return "@StorageRelationships does not generate .hasMany relationships yet — "
+                + "write this one by hand for now (deliberately deferred, not guessed at)."
+        }
+    }
+
+    public var diagnosticID: MessageID {
+        switch self {
+        case .requiresStorage:
+            return MessageID(domain: "StorageRelationshipsMacro", id: "requiresStorage")
+        case .duplicateName:
+            return MessageID(domain: "StorageRelationshipsMacro", id: "duplicateName")
+        case .alreadyDeclared:
+            return MessageID(domain: "StorageRelationshipsMacro", id: "alreadyDeclared")
+        case .malformedArgument:
+            return MessageID(domain: "StorageRelationshipsMacro", id: "malformedArgument")
+        case .hasManyNotYetSupported:
+            return MessageID(domain: "StorageRelationshipsMacro", id: "hasManyNotYetSupported")
+        }
+    }
+}

--- a/Sources/UDFMacrosMacros/DiagnosticMessage/StorageRelationshipsDiagnostic.swift
+++ b/Sources/UDFMacrosMacros/DiagnosticMessage/StorageRelationshipsDiagnostic.swift
@@ -23,7 +23,7 @@ public enum StorageRelationshipsDiagnostic: DiagnosticMessage {
         switch self {
         case .requiresStorage:
             return "@StorageRelationships requires @Storage(_:) on the same declaration — "
-                + "without it, the generated reduceRelationships(_:) is never called."
+                + "without it, the generated _reduceRelationships(_:) is never called."
         case let .duplicateName(name):
             return "Relationship name '\(name)' is used more than once. Pass an explicit "
                 + "`name:` to disambiguate two relationships to the same parent type."

--- a/Sources/UDFMacrosMacros/DiagnosticMessage/StorageRelationshipsDiagnostic.swift
+++ b/Sources/UDFMacrosMacros/DiagnosticMessage/StorageRelationshipsDiagnostic.swift
@@ -11,9 +11,9 @@ import SwiftSyntax
 public enum StorageRelationshipsDiagnostic: DiagnosticMessage {
     case requiresStorage
     case duplicateName(String)
+    case duplicateParentType(String)
     case alreadyDeclared(String)
     case malformedArgument
-    case hasManyNotYetSupported
 
     public var severity: DiagnosticSeverity {
         .error
@@ -27,15 +27,19 @@ public enum StorageRelationshipsDiagnostic: DiagnosticMessage {
         case let .duplicateName(name):
             return "Relationship name '\(name)' is used more than once. Pass an explicit "
                 + "`name:` to disambiguate two relationships to the same parent type."
+        case let .duplicateParentType(typeName):
+            return "'\(typeName)' is already used as a relationship parent type on this "
+                + "declaration. Two relationships to the same parent type — regardless of "
+                + "whether they're `.hasOne` or `.hasMany` — would generate a duplicate "
+                + "`Actions.DidLoadNestedItem<\(typeName).ID, _>` case in reduceRelationships(_:), "
+                + "even if their storage property names differ via `name:`."
         case let .alreadyDeclared(name):
             return "'\(name)' is already declared manually. @StorageRelationships will not "
                 + "overwrite it — remove the corresponding relationship from "
                 + "@StorageRelationships if this is intentional."
         case .malformedArgument:
-            return "Expected `.hasOne(Type.self)`, optionally with `name:` and/or `label:`."
-        case .hasManyNotYetSupported:
-            return "@StorageRelationships does not generate .hasMany relationships yet — "
-                + "write this one by hand for now (deliberately deferred, not guessed at)."
+            return "Expected `.hasOne(Type.self)` or `.hasMany(Type.self)`, optionally with "
+                + "`name:` and/or `label:`."
         }
     }
 
@@ -45,12 +49,12 @@ public enum StorageRelationshipsDiagnostic: DiagnosticMessage {
             return MessageID(domain: "StorageRelationshipsMacro", id: "requiresStorage")
         case .duplicateName:
             return MessageID(domain: "StorageRelationshipsMacro", id: "duplicateName")
+        case .duplicateParentType:
+            return MessageID(domain: "StorageRelationshipsMacro", id: "duplicateParentType")
         case .alreadyDeclared:
             return MessageID(domain: "StorageRelationshipsMacro", id: "alreadyDeclared")
         case .malformedArgument:
             return MessageID(domain: "StorageRelationshipsMacro", id: "malformedArgument")
-        case .hasManyNotYetSupported:
-            return MessageID(domain: "StorageRelationshipsMacro", id: "hasManyNotYetSupported")
         }
     }
 }

--- a/Sources/UDFMacrosMacros/StorageMacro.swift
+++ b/Sources/UDFMacrosMacros/StorageMacro.swift
@@ -17,6 +17,7 @@ public struct StorageMacro: MemberMacro {
         }
 
         guard let itemTypeName = itemTypeName(from: node, context: context) else {
+            context.diagnose(Diagnostic(node: Syntax(node), message: StorageDiagnostic.invalidArgument))
             return []
         }
 

--- a/Sources/UDFMacrosMacros/StorageMacro.swift
+++ b/Sources/UDFMacrosMacros/StorageMacro.swift
@@ -25,6 +25,18 @@ public struct StorageMacro: MemberMacro {
         // the standard four (see the doc comment on `@Storage`).
         let existingNames = existingMemberNames(declaration)
 
+        // @StorageRelationships is a sibling attribute, not something this
+        // macro parses — attached macros on the same declaration don't see
+        // each other's generated members during expansion, only the original
+        // declaration syntax, so this is a name-only check (mirrors
+        // @StorageRelationships' own check for @Storage's presence).
+        let hasRelationships = declaration.attributes.contains { attribute in
+            guard case let .attribute(attr) = attribute,
+                  let identifier = attr.attributeName.as(IdentifierTypeSyntax.self)
+            else { return false }
+            return identifier.name.text == "StorageRelationships"
+        }
+
         var members: [DeclSyntax] = []
 
         if !existingNames.contains("byId") {
@@ -36,32 +48,52 @@ public struct StorageMacro: MemberMacro {
         }
 
         if !existingNames.contains("reduce(_:)") {
-            let defaultCase = existingNames.contains("reduceCustom(_:)")
-                ? "reduceCustom(action)"
-                : "break"
+            // Not exclusive-or: reduceRelationships(_:) and reduceCustom(_:)
+            // each have their own switch with default: break, so calling
+            // both unconditionally is safe regardless of which one an
+            // action actually matches.
+            var defaultCaseLines: [String] = []
+            if hasRelationships {
+                defaultCaseLines.append("reduceRelationships(action)")
+            }
+            if existingNames.contains("reduceCustom(_:)") {
+                defaultCaseLines.append("reduceCustom(action)")
+            }
+            if defaultCaseLines.isEmpty {
+                defaultCaseLines.append("break")
+            }
 
-            members.append(
-                """
-                mutating func reduce(_ action: some Action) {
-                    switch action {
-                    case let action as Actions.DidLoadItems<\(raw: itemTypeName)>:
-                        byId.insert(items: action.items)
+            // Built as a flat line array + single DeclSyntax(stringLiteral:)
+            // rather than a multi-line \(raw:) interpolation embedded inside
+            // more literal template text — the latter caused a real
+            // indentation bug (reduceCustom(action) picked up extra leading
+            // spaces) whenever defaultCaseLines had more than one line, since
+            // a multi-line raw interpolation followed by more outer-literal
+            // lines in the same triple-quote doesn't compose predictably.
+            var reduceLines: [String] = [
+                "mutating func reduce(_ action: some Action) {",
+                "    switch action {",
+                "    case let action as Actions.DidLoadItems<\(itemTypeName)>:",
+                "        byId.insert(items: action.items)",
+                "",
+                "    case let action as Actions.DidLoadItem<\(itemTypeName)>:",
+                "        byId.insert(item: action.item)",
+                "",
+                "    case let action as Actions.DidUpdateItem<\(itemTypeName)>:",
+                "        byId[action.item.id] = action.item",
+                "",
+                "    case let action as Actions.DeleteItem<\(itemTypeName)>:",
+                "        byId.removeValue(forKey: action.item.id)",
+                "",
+                "    default:",
+            ]
+            for line in defaultCaseLines {
+                reduceLines.append("        \(line)")
+            }
+            reduceLines.append("    }")
+            reduceLines.append("}")
 
-                    case let action as Actions.DidLoadItem<\(raw: itemTypeName)>:
-                        byId.insert(item: action.item)
-
-                    case let action as Actions.DidUpdateItem<\(raw: itemTypeName)>:
-                        byId[action.item.id] = action.item
-
-                    case let action as Actions.DeleteItem<\(raw: itemTypeName)>:
-                        byId.removeValue(forKey: action.item.id)
-
-                    default:
-                        \(raw: defaultCase)
-                    }
-                }
-                """
-            )
+            members.append(DeclSyntax(stringLiteral: reduceLines.joined(separator: "\n")))
         }
 
         let accessorName = "\(lowerCamelCase(itemTypeName))By"

--- a/Sources/UDFMacrosMacros/StorageMacro.swift
+++ b/Sources/UDFMacrosMacros/StorageMacro.swift
@@ -1,0 +1,140 @@
+import SwiftCompilerPlugin
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct StorageMacro: MemberMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        conformingTo _: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard isSupportedDeclSyntax(declaration) else {
+            context.diagnose(Diagnostic(node: Syntax(node), message: StorageDiagnostic.unsupportedType))
+            return []
+        }
+
+        guard let itemTypeName = itemTypeName(from: node, context: context) else {
+            return []
+        }
+
+        // Don't clobber members already written by hand — this is the escape
+        // hatch for a storage that needs a bespoke `reduce` case alongside
+        // the standard four (see the doc comment on `@Storage`).
+        let existingNames = existingMemberNames(declaration)
+
+        var members: [DeclSyntax] = []
+
+        if !existingNames.contains("byId") {
+            members.append(
+                """
+                var byId: [\(raw: itemTypeName).ID: \(raw: itemTypeName)] = [:]
+                """
+            )
+        }
+
+        if !existingNames.contains("reduce") {
+            members.append(
+                """
+                mutating func reduce(_ action: some Action) {
+                    switch action {
+                    case let action as Actions.DidLoadItems<\(raw: itemTypeName)>:
+                        byId.insert(items: action.items)
+
+                    case let action as Actions.DidLoadItem<\(raw: itemTypeName)>:
+                        byId.insert(item: action.item)
+
+                    case let action as Actions.DidUpdateItem<\(raw: itemTypeName)>:
+                        byId[action.item.id] = action.item
+
+                    case let action as Actions.DeleteItem<\(raw: itemTypeName)>:
+                        byId.removeValue(forKey: action.item.id)
+
+                    default:
+                        break
+                    }
+                }
+                """
+            )
+        }
+
+        let accessorName = "\(lowerCamelCase(itemTypeName))By"
+
+        if !existingNames.contains(accessorName) {
+            members.append(
+                """
+                func \(raw: accessorName)(id: \(raw: itemTypeName).ID) -> \(raw: itemTypeName) {
+                    byId[id] ?? .empty
+                }
+                """
+            )
+        }
+
+        return members
+    }
+
+    /// `Dish` -> `dish`, `FAQItem` -> `faqItem`. Only the leading run of
+    /// uppercase letters is lowered, so acronym-led names stay readable.
+    private static func lowerCamelCase(_ typeName: String) -> String {
+        guard let first = typeName.first else { return typeName }
+
+        if typeName.count == 1 {
+            return typeName.lowercased()
+        }
+
+        let leadingUppercaseRun = typeName.prefix { $0.isUppercase }
+
+        if leadingUppercaseRun.count <= 1 {
+            return first.lowercased() + typeName.dropFirst()
+        }
+
+        // Keep the last uppercase letter of the run attached to the next word
+        // (e.g. "FAQItem" -> leading run "FAQI", back off one -> "FAQ" + "Item").
+        let wordBoundary = typeName.index(before: leadingUppercaseRun.endIndex)
+        return typeName[..<wordBoundary].lowercased() + typeName[wordBoundary...]
+    }
+
+    /// Expects exactly one argument shaped like `Movie.self`.
+    private static func itemTypeName(
+        from node: AttributeSyntax,
+        context: some MacroExpansionContext
+    ) -> String? {
+        guard
+            let arguments = node.arguments?.as(LabeledExprListSyntax.self),
+            arguments.count == 1,
+            let firstArg = arguments.first,
+            let memberAccess = firstArg.expression.as(MemberAccessExprSyntax.self),
+            memberAccess.declName.baseName.text == "self",
+            let base = memberAccess.base?.as(DeclReferenceExprSyntax.self)
+        else {
+            context.diagnose(Diagnostic(node: Syntax(node), message: StorageDiagnostic.invalidArgument))
+            return nil
+        }
+
+        return base.baseName.text
+    }
+
+    private static func existingMemberNames(_ declaration: some DeclGroupSyntax) -> Set<String> {
+        var names: Set<String> = []
+
+        for member in declaration.memberBlock.members {
+            if let varDecl = member.decl.as(VariableDeclSyntax.self) {
+                for binding in varDecl.bindings {
+                    if let identifier = binding.pattern.as(IdentifierPatternSyntax.self) {
+                        names.insert(identifier.identifier.text)
+                    }
+                }
+            } else if let funcDecl = member.decl.as(FunctionDeclSyntax.self) {
+                names.insert(funcDecl.name.text)
+            }
+        }
+
+        return names
+    }
+
+    private static func isSupportedDeclSyntax(_ decl: DeclGroupSyntax) -> Bool {
+        decl.is(StructDeclSyntax.self)
+    }
+}

--- a/Sources/UDFMacrosMacros/StorageMacro.swift
+++ b/Sources/UDFMacrosMacros/StorageMacro.swift
@@ -49,13 +49,13 @@ public struct StorageMacro: MemberMacro {
         }
 
         if !existingNames.contains("reduce(_:)") {
-            // Not exclusive-or: reduceRelationships(_:) and reduceCustom(_:)
+            // Not exclusive-or: _reduceRelationships(_:) and reduceCustom(_:)
             // each have their own switch with default: break, so calling
             // both unconditionally is safe regardless of which one an
             // action actually matches.
             var defaultCaseLines: [String] = []
             if hasRelationships {
-                defaultCaseLines.append("reduceRelationships(action)")
+                defaultCaseLines.append("_reduceRelationships(action)")
             }
             if existingNames.contains("reduceCustom(_:)") {
                 defaultCaseLines.append("reduceCustom(action)")
@@ -174,9 +174,7 @@ public struct StorageMacro: MemberMacro {
     /// silently skip generating `restaurantBy(id:)` whenever any other
     /// `restaurantBy(...)` overload already existed.
     private static func functionSignature(_ funcDecl: FunctionDeclSyntax) -> String {
-        let labels = funcDecl.signature.parameterClause.parameters.map { param in
-            param.firstName.text == "_" ? "_" : param.firstName.text
-        }
+        let labels = funcDecl.signature.parameterClause.parameters.map { $0.firstName.text }
         return "\(funcDecl.name.text)(\(labels.map { "\($0):" }.joined()))"
     }
 

--- a/Sources/UDFMacrosMacros/StorageMacro.swift
+++ b/Sources/UDFMacrosMacros/StorageMacro.swift
@@ -49,13 +49,13 @@ public struct StorageMacro: MemberMacro {
         }
 
         if !existingNames.contains("reduce(_:)") {
-            // Not exclusive-or: reduceRelationships(_:) and reduceCustom(_:)
+            // Not exclusive-or: _reduceRelationships(_:) and reduceCustom(_:)
             // each have their own switch with default: break, so calling
             // both unconditionally is safe regardless of which one an
             // action actually matches.
             var defaultCaseLines: [String] = []
             if hasRelationships {
-                defaultCaseLines.append("reduceRelationships(action)")
+                defaultCaseLines.append("_reduceRelationships(action)")
             }
             if existingNames.contains("reduceCustom(_:)") {
                 defaultCaseLines.append("reduceCustom(action)")

--- a/Sources/UDFMacrosMacros/StorageMacro.swift
+++ b/Sources/UDFMacrosMacros/StorageMacro.swift
@@ -35,7 +35,11 @@ public struct StorageMacro: MemberMacro {
             )
         }
 
-        if !existingNames.contains("reduce") {
+        if !existingNames.contains("reduce(_:)") {
+            let defaultCase = existingNames.contains("reduceCustom(_:)")
+                ? "reduceCustom(action)"
+                : "break"
+
             members.append(
                 """
                 mutating func reduce(_ action: some Action) {
@@ -53,7 +57,7 @@ public struct StorageMacro: MemberMacro {
                         byId.removeValue(forKey: action.item.id)
 
                     default:
-                        break
+                        \(raw: defaultCase)
                     }
                 }
                 """
@@ -62,7 +66,7 @@ public struct StorageMacro: MemberMacro {
 
         let accessorName = "\(lowerCamelCase(itemTypeName))By"
 
-        if !existingNames.contains(accessorName) {
+        if !existingNames.contains("\(accessorName)(id:)") {
             members.append(
                 """
                 func \(raw: accessorName)(id: \(raw: itemTypeName).ID) -> \(raw: itemTypeName) {
@@ -127,11 +131,24 @@ public struct StorageMacro: MemberMacro {
                     }
                 }
             } else if let funcDecl = member.decl.as(FunctionDeclSyntax.self) {
-                names.insert(funcDecl.name.text)
+                names.insert(functionSignature(funcDecl))
             }
         }
 
         return names
+    }
+
+    /// Builds a name+labels key (e.g. "restaurantBy(id:)", "reduce(_:)") so
+    /// overloads sharing a base name — `restaurantBy(review:)` vs the
+    /// macro's own `restaurantBy(id:)` — aren't mistaken for the same
+    /// member. Matching on bare name here previously caused the macro to
+    /// silently skip generating `restaurantBy(id:)` whenever any other
+    /// `restaurantBy(...)` overload already existed.
+    private static func functionSignature(_ funcDecl: FunctionDeclSyntax) -> String {
+        let labels = funcDecl.signature.parameterClause.parameters.map { param in
+            param.firstName.text == "_" ? "_" : param.firstName.text
+        }
+        return "\(funcDecl.name.text)(\(labels.map { "\($0):" }.joined()))"
     }
 
     private static func isSupportedDeclSyntax(_ decl: DeclGroupSyntax) -> Bool {

--- a/Sources/UDFMacrosMacros/StorageMacro.swift
+++ b/Sources/UDFMacrosMacros/StorageMacro.swift
@@ -104,7 +104,7 @@ public struct StorageMacro: MemberMacro {
     /// Expects exactly one argument shaped like `Movie.self`.
     private static func itemTypeName(
         from node: AttributeSyntax,
-        context: some MacroExpansionContext
+        context _: some MacroExpansionContext
     ) -> String? {
         guard
             let arguments = node.arguments?.as(LabeledExprListSyntax.self),
@@ -114,7 +114,6 @@ public struct StorageMacro: MemberMacro {
             memberAccess.declName.baseName.text == "self",
             let base = memberAccess.base?.as(DeclReferenceExprSyntax.self)
         else {
-            context.diagnose(Diagnostic(node: Syntax(node), message: StorageDiagnostic.invalidArgument))
             return nil
         }
 

--- a/Sources/UDFMacrosMacros/StorageMacro.swift
+++ b/Sources/UDFMacrosMacros/StorageMacro.swift
@@ -65,12 +65,9 @@ public struct StorageMacro: MemberMacro {
             }
 
             // Built as a flat line array + single DeclSyntax(stringLiteral:)
-            // rather than a multi-line \(raw:) interpolation embedded inside
-            // more literal template text — the latter caused a real
-            // indentation bug (reduceCustom(action) picked up extra leading
-            // spaces) whenever defaultCaseLines had more than one line, since
-            // a multi-line raw interpolation followed by more outer-literal
-            // lines in the same triple-quote doesn't compose predictably.
+            // rather than a multi-line \(raw:) interpolation followed by more
+            // literal text in the same triple-quote — the latter doesn't
+            // reindent predictably once defaultCaseLines has more than one line.
             var reduceLines: [String] = [
                 "mutating func reduce(_ action: some Action) {",
                 "    switch action {",

--- a/Sources/UDFMacrosMacros/StorageRelationshipsMacro.swift
+++ b/Sources/UDFMacrosMacros/StorageRelationshipsMacro.swift
@@ -1,0 +1,248 @@
+//
+//  StorageRelationshipsMacro.swift
+//  UDFMacros
+//
+//  Created by Oleksandr Bodnar on 29.07.2026.
+//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+// MARK: - Parsed relationship model
+
+private struct ParsedHasOne {
+    let parentTypeName: String
+    /// Storage dictionary name, e.g. "byReviewId". Matches the established
+    /// `by<ParentType>Id` convention seen in hand-written relationships
+    /// (byReviewId, byFortuneResultId, byDishId).
+    let propertyName: String
+    /// Accessor argument label, e.g. "review". NOT mechanically derived from
+    /// parentTypeName by default in every case in the existing codebase
+    /// (`fortuneResult` for FortuneWheelResult, `dishID` for Dish) — so this
+    /// is independently overridable via `label:`, not tied to `propertyName`.
+    let argumentLabel: String
+}
+
+// MARK: - Macro
+
+public struct StorageRelationshipsMacro: MemberMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        // 1. Symmetric check: @Storage must be present on the same declaration.
+        let hasStorageAttribute = declaration.attributes.contains { attribute in
+            guard case let .attribute(attr) = attribute,
+                  let identifier = attr.attributeName.as(IdentifierTypeSyntax.self)
+            else { return false }
+            return identifier.name.text == "Storage"
+        }
+        guard hasStorageAttribute else {
+            context.diagnose(Diagnostic(node: node, message: StorageRelationshipsDiagnostic.requiresStorage))
+            return []
+        }
+
+        // 2. Pull the item type out of the sibling @Storage(Item.self) attribute.
+        guard let itemTypeName = storageItemTypeName(from: declaration) else {
+            // @Storage's own macro already diagnoses a malformed argument.
+            return []
+        }
+
+        guard case let .argumentList(arguments) = node.arguments else {
+            return []
+        }
+
+        var relationships: [ParsedHasOne] = []
+        var usedPropertyNames: Set<String> = []
+        var sawError = false
+
+        for argument in arguments {
+            guard let call = argument.expression.as(FunctionCallExprSyntax.self),
+                  let member = call.calledExpression.as(MemberAccessExprSyntax.self)
+            else {
+                context.diagnose(Diagnostic(node: argument, message: StorageRelationshipsDiagnostic.malformedArgument))
+                sawError = true
+                continue
+            }
+
+            switch member.declName.baseName.text {
+            case "hasMany":
+                context.diagnose(Diagnostic(node: argument, message: StorageRelationshipsDiagnostic.hasManyNotYetSupported))
+                sawError = true
+                continue
+            case "hasOne":
+                break
+            default:
+                context.diagnose(Diagnostic(node: argument, message: StorageRelationshipsDiagnostic.malformedArgument))
+                sawError = true
+                continue
+            }
+
+            guard let firstArg = call.arguments.first,
+                  let typeMemberAccess = firstArg.expression.as(MemberAccessExprSyntax.self),
+                  typeMemberAccess.declName.baseName.text == "self",
+                  let typeBase = typeMemberAccess.base?.as(DeclReferenceExprSyntax.self)
+            else {
+                context.diagnose(Diagnostic(node: argument, message: StorageRelationshipsDiagnostic.malformedArgument))
+                sawError = true
+                continue
+            }
+            let parentTypeName = typeBase.baseName.text
+
+            let explicitName = stringArgument(call, label: "name")
+            let explicitLabel = stringArgument(call, label: "label")
+
+            let propertyName = explicitName ?? "by\(parentTypeName)Id"
+            let argumentLabel = explicitLabel ?? lowerCamelCase(parentTypeName)
+
+            guard usedPropertyNames.insert(propertyName).inserted else {
+                context.diagnose(Diagnostic(node: argument, message: StorageRelationshipsDiagnostic.duplicateName(propertyName)))
+                sawError = true
+                continue
+            }
+
+            relationships.append(ParsedHasOne(
+                parentTypeName: parentTypeName,
+                propertyName: propertyName,
+                argumentLabel: argumentLabel
+            ))
+        }
+
+        guard !sawError else { return [] }
+
+        // 3. Escape hatch, symmetric with @Storage's own: don't regenerate
+        //    members already written by hand. Matched by full signature.
+        let existingPropertyNames = existingStoredPropertyNames(in: declaration)
+        let existingFunctionSignatures = existingFunctionSignatures(in: declaration)
+
+        if existingFunctionSignatures.contains("reduceRelationships(_)") {
+            context.diagnose(Diagnostic(
+                node: node,
+                message: StorageRelationshipsDiagnostic.alreadyDeclared("reduceRelationships(_:)")
+            ))
+            return []
+        }
+
+        var members: [DeclSyntax] = []
+
+        // 4. Storage property per relationship — `var by<Parent>Id: [Parent.ID: Item.ID]`.
+        for relationship in relationships where !existingPropertyNames.contains(relationship.propertyName) {
+            members.append(DeclSyntax(stringLiteral:
+                "var \(relationship.propertyName): [\(relationship.parentTypeName).ID: \(itemTypeName).ID] = [:]"
+            ))
+        }
+
+        // 5. Combined reduceRelationships(_:) — composes with @Storage's
+        //    default: branch without colliding with a user-written reduceCustom(_:).
+        //
+        //    Only Actions.DidLoadNestedItem<ParentId, Nested> is generated here —
+        //    it's the one confirmed to exist in UDFMacros/UDF's own Actions.swift.
+        //    A bulk "by parents" load is deliberately NOT generated: that action
+        //    (however it's named/shaped) lives at the app level, not the framework
+        //    level, and its shape isn't standardized across apps — generating a
+        //    reference to it would break compilation wherever it doesn't exist or
+        //    doesn't match. If a relationship needs bulk-load handling, add that
+        //    case by hand in reduceCustom(_:), which still sees byId/by<Parent>Id.
+        //
+        //    Built as a flat line array + single DeclSyntax(stringLiteral:) rather
+        //    than a multi-line \(raw:) interpolation embedded inside more literal
+        //    template text — the latter caused a real indentation bug (default:/
+        //    break picked up extra leading spaces) since a multi-line raw
+        //    interpolation followed by more outer-literal lines in the same
+        //    triple-quote doesn't compose the way a single self-contained literal
+        //    does (which is how @Storage's own reduce() cases are written).
+        var reduceRelationshipsLines: [String] = [
+            "mutating func reduceRelationships(_ action: some Action) {",
+            "    switch action {",
+        ]
+        for relationship in relationships {
+            reduceRelationshipsLines.append("    case let action as Actions.DidLoadNestedItem<\(relationship.parentTypeName).ID, \(itemTypeName)>:")
+            reduceRelationshipsLines.append("        byId.insert(item: action.item)")
+            reduceRelationshipsLines.append("        \(relationship.propertyName)[action.parentId] = action.item.id")
+            reduceRelationshipsLines.append("")
+        }
+        reduceRelationshipsLines.append("    default:")
+        reduceRelationshipsLines.append("        break")
+        reduceRelationshipsLines.append("    }")
+        reduceRelationshipsLines.append("}")
+        members.append(DeclSyntax(stringLiteral: reduceRelationshipsLines.joined(separator: "\n")))
+
+        // 6. Accessor per relationship — overload of `<item>By(...)`, matching
+        //    @Storage's own accessor base name (e.g. `restaurantBy(id:)`).
+        //    Returns Item.ID?, matching the hand-written accessors.
+        let accessorBaseName = "\(lowerCamelCase(itemTypeName))By"
+        for relationship in relationships {
+            let signatureKey = "\(accessorBaseName)(\(relationship.argumentLabel))"
+            guard !existingFunctionSignatures.contains(signatureKey) else { continue }
+            let accessorLines = [
+                "func \(accessorBaseName)(\(relationship.argumentLabel) id: \(relationship.parentTypeName).ID) -> \(itemTypeName).ID? {",
+                "    \(relationship.propertyName)[id]",
+                "}",
+            ]
+            members.append(DeclSyntax(stringLiteral: accessorLines.joined(separator: "\n")))
+        }
+
+        return members
+    }
+
+    // MARK: - Helpers
+
+    private static func stringArgument(_ call: FunctionCallExprSyntax, label: String) -> String? {
+        call.arguments.first(where: { $0.label?.text == label })?
+            .expression.as(StringLiteralExprSyntax.self)?
+            .segments.first?.as(StringSegmentSyntax.self)?
+            .content.text
+    }
+
+    private static func storageItemTypeName(from declaration: some DeclGroupSyntax) -> String? {
+        for attribute in declaration.attributes {
+            guard case let .attribute(attr) = attribute,
+                  let identifier = attr.attributeName.as(IdentifierTypeSyntax.self),
+                  identifier.name.text == "Storage",
+                  case let .argumentList(args)? = attr.arguments,
+                  let first = args.first,
+                  let memberAccess = first.expression.as(MemberAccessExprSyntax.self),
+                  memberAccess.declName.baseName.text == "self",
+                  let base = memberAccess.base?.as(DeclReferenceExprSyntax.self)
+            else { continue }
+            return base.baseName.text
+        }
+        return nil
+    }
+
+    private static func existingStoredPropertyNames(in declaration: some DeclGroupSyntax) -> Set<String> {
+        var names: Set<String> = []
+        for member in declaration.memberBlock.members {
+            guard let variable = member.decl.as(VariableDeclSyntax.self) else { continue }
+            for binding in variable.bindings {
+                if let identifier = binding.pattern.as(IdentifierPatternSyntax.self) {
+                    names.insert(identifier.identifier.text)
+                }
+            }
+        }
+        return names
+    }
+
+    /// Matches on name + parameter labels (e.g. "reduceRelationships(_)",
+    /// "restaurantBy(review)") — the same fix already applied once in
+    /// @Storage's own escape-hatch check, for the same reason: matching bare
+    /// names alone would mistake unrelated overloads for each other.
+    private static func existingFunctionSignatures(in declaration: some DeclGroupSyntax) -> Set<String> {
+        var signatures: Set<String> = []
+        for member in declaration.memberBlock.members {
+            guard let function = member.decl.as(FunctionDeclSyntax.self) else { continue }
+            let labels = function.signature.parameterClause.parameters
+                .map { $0.firstName.text }
+                .joined(separator: ",")
+            signatures.insert("\(function.name.text)(\(labels))")
+        }
+        return signatures
+    }
+
+    private static func lowerCamelCase(_ name: String) -> String {
+        guard let first = name.first else { return name }
+        return first.lowercased() + name.dropFirst()
+    }
+}

--- a/Sources/UDFMacrosMacros/StorageRelationshipsMacro.swift
+++ b/Sources/UDFMacrosMacros/StorageRelationshipsMacro.swift
@@ -9,18 +9,22 @@ import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxMacros
 
-// MARK: - Parsed relationship model
+// MARK: - Parsed relationship models
 
 private struct ParsedHasOne {
     let parentTypeName: String
-    /// Storage dictionary name, e.g. "byReviewId". Matches the established
-    /// `by<ParentType>Id` convention seen in hand-written relationships
-    /// (byReviewId, byFortuneResultId, byDishId).
     let propertyName: String
-    /// Accessor argument label, e.g. "review". NOT mechanically derived from
-    /// parentTypeName by default in every case in the existing codebase
-    /// (`fortuneResult` for FortuneWheelResult, `dishID` for Dish) — so this
-    /// is independently overridable via `label:`, not tied to `propertyName`.
+    let argumentLabel: String
+}
+
+// mirrors ParsedHasOne. Kept as a separate type (not a shared enum) because
+// hasOne/hasMany genuinely generate different code shapes downstream (storage
+// value type, reduce-case bodies, accessor return type) — collapsing them into
+// one type with a `kind` flag would just push an `if kind == .hasMany` into
+// every codegen site instead of keeping each shape in its own place.
+private struct ParsedHasMany {
+    let parentTypeName: String
+    let propertyName: String
     let argumentLabel: String
 }
 
@@ -32,7 +36,6 @@ public struct StorageRelationshipsMacro: MemberMacro {
         providingMembersOf declaration: some DeclGroupSyntax,
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
-        // 1. Symmetric check: @Storage must be present on the same declaration.
         let hasStorageAttribute = declaration.attributes.contains { attribute in
             guard case let .attribute(attr) = attribute,
                   let identifier = attr.attributeName.as(IdentifierTypeSyntax.self)
@@ -44,9 +47,7 @@ public struct StorageRelationshipsMacro: MemberMacro {
             return []
         }
 
-        // 2. Pull the item type out of the sibling @Storage(Item.self) attribute.
         guard let itemTypeName = storageItemTypeName(from: declaration) else {
-            // @Storage's own macro already diagnoses a malformed argument.
             return []
         }
 
@@ -54,8 +55,14 @@ public struct StorageRelationshipsMacro: MemberMacro {
             return []
         }
 
-        var relationships: [ParsedHasOne] = []
+        var hasOneRelationships: [ParsedHasOne] = []
+        var hasManyRelationships: [ParsedHasMany] = []
         var usedPropertyNames: Set<String> = []
+        // tracks parentTypeName across BOTH hasOne and hasMany. This is the
+        // real collision surface — two relationships to the same parent type
+        // generate the same `Actions.DidLoadNestedItem<Parent.ID, Item>` case
+        // regardless of what the storage property is named.
+        var usedParentTypeNames: Set<String> = []
         var sawError = false
 
         for argument in arguments {
@@ -67,14 +74,8 @@ public struct StorageRelationshipsMacro: MemberMacro {
                 continue
             }
 
-            switch member.declName.baseName.text {
-            case "hasMany":
-                context.diagnose(Diagnostic(node: argument, message: StorageRelationshipsDiagnostic.hasManyNotYetSupported))
-                sawError = true
-                continue
-            case "hasOne":
-                break
-            default:
+            let kind = member.declName.baseName.text
+            guard kind == "hasOne" || kind == "hasMany" else {
                 context.diagnose(Diagnostic(node: argument, message: StorageRelationshipsDiagnostic.malformedArgument))
                 sawError = true
                 continue
@@ -91,9 +92,21 @@ public struct StorageRelationshipsMacro: MemberMacro {
             }
             let parentTypeName = typeBase.baseName.text
 
+            guard usedParentTypeNames.insert(parentTypeName).inserted else {
+                context.diagnose(Diagnostic(
+                    node: argument,
+                    message: StorageRelationshipsDiagnostic.duplicateParentType(parentTypeName)
+                ))
+                sawError = true
+                continue
+            }
+
             let explicitName = stringArgument(call, label: "name")
             let explicitLabel = stringArgument(call, label: "label")
 
+            // Same default-naming scheme for both kinds: "by<Parent>Id".
+            // No pluralization here — the key is always a single Parent.ID,
+            // even for hasMany (the "many" lives in the value's OrderedSet).
             let propertyName = explicitName ?? "by\(parentTypeName)Id"
             let argumentLabel = explicitLabel ?? lowerCamelCase(parentTypeName)
 
@@ -103,17 +116,23 @@ public struct StorageRelationshipsMacro: MemberMacro {
                 continue
             }
 
-            relationships.append(ParsedHasOne(
-                parentTypeName: parentTypeName,
-                propertyName: propertyName,
-                argumentLabel: argumentLabel
-            ))
+            if kind == "hasOne" {
+                hasOneRelationships.append(ParsedHasOne(
+                    parentTypeName: parentTypeName,
+                    propertyName: propertyName,
+                    argumentLabel: argumentLabel
+                ))
+            } else {
+                hasManyRelationships.append(ParsedHasMany(
+                    parentTypeName: parentTypeName,
+                    propertyName: propertyName,
+                    argumentLabel: argumentLabel
+                ))
+            }
         }
 
         guard !sawError else { return [] }
 
-        // 3. Escape hatch, symmetric with @Storage's own: don't regenerate
-        //    members already written by hand. Matched by full signature.
         let existingPropertyNames = existingStoredPropertyNames(in: declaration)
         let existingFunctionSignatures = existingFunctionSignatures(in: declaration)
 
@@ -127,40 +146,49 @@ public struct StorageRelationshipsMacro: MemberMacro {
 
         var members: [DeclSyntax] = []
 
-        // 4. Storage property per relationship — `var by<Parent>Id: [Parent.ID: Item.ID]`.
-        for relationship in relationships where !existingPropertyNames.contains(relationship.propertyName) {
+        // Storage properties — hasOne
+        for relationship in hasOneRelationships where !existingPropertyNames.contains(relationship.propertyName) {
             members.append(DeclSyntax(stringLiteral:
                 "var \(relationship.propertyName): [\(relationship.parentTypeName).ID: \(itemTypeName).ID] = [:]"
             ))
         }
 
-        // 5. Combined reduceRelationships(_:) — composes with @Storage's
-        //    default: branch without colliding with a user-written reduceCustom(_:).
-        //
-        //    Only Actions.DidLoadNestedItem<ParentId, Nested> is generated here —
-        //    it's the one confirmed to exist in UDFMacros/UDF's own Actions.swift.
-        //    A bulk "by parents" load is deliberately NOT generated: that action
-        //    (however it's named/shaped) lives at the app level, not the framework
-        //    level, and its shape isn't standardized across apps — generating a
-        //    reference to it would break compilation wherever it doesn't exist or
-        //    doesn't match. If a relationship needs bulk-load handling, add that
-        //    case by hand in reduceCustom(_:), which still sees byId/by<Parent>Id.
-        //
-        //    Built as a flat line array + single DeclSyntax(stringLiteral:) rather
-        //    than a multi-line \(raw:) interpolation embedded inside more literal
-        //    template text — the latter caused a real indentation bug (default:/
-        //    break picked up extra leading spaces) since a multi-line raw
-        //    interpolation followed by more outer-literal lines in the same
-        //    triple-quote doesn't compose the way a single self-contained literal
-        //    does (which is how @Storage's own reduce() cases are written).
+        // Storage properties — hasMany
+        for relationship in hasManyRelationships where !existingPropertyNames.contains(relationship.propertyName) {
+            members.append(DeclSyntax(stringLiteral:
+                "var \(relationship.propertyName): [\(relationship.parentTypeName).ID: OrderedSet<\(itemTypeName).ID>] = [:]"
+            ))
+        }
+
+        // reduceRelationships(_:) — both kinds combined into one switch.
         var reduceRelationshipsLines: [String] = [
             "mutating func reduceRelationships(_ action: some Action) {",
             "    switch action {",
         ]
-        for relationship in relationships {
+        for relationship in hasOneRelationships {
             reduceRelationshipsLines.append("    case let action as Actions.DidLoadNestedItem<\(relationship.parentTypeName).ID, \(itemTypeName)>:")
             reduceRelationshipsLines.append("        byId.insert(item: action.item)")
             reduceRelationshipsLines.append("        \(relationship.propertyName)[action.parentId] = action.item.id")
+            reduceRelationshipsLines.append("")
+        }
+        // hasMany's three cases — additive (.append), matching the
+        // union convention confirmed in AllDishes/AllReviews.
+        for relationship in hasManyRelationships {
+            reduceRelationshipsLines.append("    case let action as Actions.DidLoadNestedItem<\(relationship.parentTypeName).ID, \(itemTypeName)>:")
+            reduceRelationshipsLines.append("        byId.insert(item: action.item)")
+            reduceRelationshipsLines.append("        \(relationship.propertyName).append(action.item.id, by: action.parentId)")
+            reduceRelationshipsLines.append("")
+
+            reduceRelationshipsLines.append("    case let action as Actions.DidLoadNestedItems<\(relationship.parentTypeName).ID, \(itemTypeName)>:")
+            reduceRelationshipsLines.append("        byId.insert(items: action.items)")
+            reduceRelationshipsLines.append("        \(relationship.propertyName).append(action.items.ids, by: action.parentId)")
+            reduceRelationshipsLines.append("")
+
+            reduceRelationshipsLines.append("    case let action as Actions.DidLoadNestedByParents<\(relationship.parentTypeName).ID, \(itemTypeName)>:")
+            reduceRelationshipsLines.append("        for (parentId, children) in action.dictionary {")
+            reduceRelationshipsLines.append("            byId.insert(items: children)")
+            reduceRelationshipsLines.append("            \(relationship.propertyName).append(children.ids, by: parentId)")
+            reduceRelationshipsLines.append("        }")
             reduceRelationshipsLines.append("")
         }
         reduceRelationshipsLines.append("    default:")
@@ -169,11 +197,9 @@ public struct StorageRelationshipsMacro: MemberMacro {
         reduceRelationshipsLines.append("}")
         members.append(DeclSyntax(stringLiteral: reduceRelationshipsLines.joined(separator: "\n")))
 
-        // 6. Accessor per relationship — overload of `<item>By(...)`, matching
-        //    @Storage's own accessor base name (e.g. `restaurantBy(id:)`).
-        //    Returns Item.ID?, matching the hand-written accessors.
+        // Accessors — hasOne: singular, optional Item.ID?
         let accessorBaseName = "\(lowerCamelCase(itemTypeName))By"
-        for relationship in relationships {
+        for relationship in hasOneRelationships {
             let signatureKey = "\(accessorBaseName)(\(relationship.argumentLabel))"
             guard !existingFunctionSignatures.contains(signatureKey) else { continue }
             let accessorLines = [
@@ -184,10 +210,27 @@ public struct StorageRelationshipsMacro: MemberMacro {
             members.append(DeclSyntax(stringLiteral: accessorLines.joined(separator: "\n")))
         }
 
+        // Accessors — hasMany: pluralized name, [Item.ID] return.
+        // Naive "+s" pluralization — cosmetic only (doesn't affect the storage
+        // property name, which stays singular). Irregular plurals won't be
+        // exact; the existing-signature escape hatch lets a hand-written
+        // correctly-pluralized accessor override this one.
+        let accessorManyBaseName = "\(pluralize(lowerCamelCase(itemTypeName)))By"
+        for relationship in hasManyRelationships {
+            let signatureKey = "\(accessorManyBaseName)(\(relationship.argumentLabel))"
+            guard !existingFunctionSignatures.contains(signatureKey) else { continue }
+            let accessorLines = [
+                "func \(accessorManyBaseName)(\(relationship.argumentLabel) id: \(relationship.parentTypeName).ID) -> [\(itemTypeName).ID] {",
+                "    Array(\(relationship.propertyName)[id] ?? [])",
+                "}",
+            ]
+            members.append(DeclSyntax(stringLiteral: accessorLines.joined(separator: "\n")))
+        }
+
         return members
     }
 
-    // MARK: - Helpers
+    // MARK: - Helpers (unchanged from the hasOne-only version)
 
     private static func stringArgument(_ call: FunctionCallExprSyntax, label: String) -> String? {
         call.arguments.first(where: { $0.label?.text == label })?
@@ -244,5 +287,20 @@ public struct StorageRelationshipsMacro: MemberMacro {
     private static func lowerCamelCase(_ name: String) -> String {
         guard let first = name.first else { return name }
         return first.lowercased() + name.dropFirst()
+    }
+
+    private static func pluralize(_ word: String) -> String {
+        let lower = word.lowercased()
+        if lower.hasSuffix("s") || lower.hasSuffix("x") || lower.hasSuffix("z")
+            || lower.hasSuffix("ch") || lower.hasSuffix("sh")
+        {
+            return word + "es"
+        }
+        if lower.hasSuffix("y"), let beforeY = word.dropLast().last,
+           !"aeiou".contains(beforeY.lowercased())
+        {
+            return String(word.dropLast()) + "ies"
+        }
+        return word + "s"
     }
 }

--- a/Sources/UDFMacrosMacros/StorageRelationshipsMacro.swift
+++ b/Sources/UDFMacrosMacros/StorageRelationshipsMacro.swift
@@ -13,14 +13,10 @@ import SwiftSyntaxMacros
 
 private struct ParsedHasOne {
     let parentTypeName: String
-    /// Storage dictionary name, e.g. "byReviewId". Matches the established
-    /// `by<ParentType>Id` convention seen in hand-written relationships
-    /// (byReviewId, byFortuneResultId, byDishId).
+    /// Storage dictionary name, e.g. "byReviewId" (see `StorageRelationships` doc).
     let propertyName: String
-    /// Accessor argument label, e.g. "review". NOT mechanically derived from
-    /// parentTypeName by default in every case in the existing codebase
-    /// (`fortuneResult` for FortuneWheelResult, `dishID` for Dish) — so this
-    /// is independently overridable via `label:`, not tied to `propertyName`.
+    /// Accessor argument label, e.g. "review" — independently overridable via
+    /// `label:` (see `StorageRelationships` doc for why it's separate from `name:`).
     let argumentLabel: String
 }
 
@@ -32,7 +28,7 @@ public struct StorageRelationshipsMacro: MemberMacro {
         providingMembersOf declaration: some DeclGroupSyntax,
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
-        // 1. Symmetric check: @Storage must be present on the same declaration.
+        // Symmetric check: @Storage must be present on the same declaration.
         let hasStorageAttribute = declaration.attributes.contains { attribute in
             guard case let .attribute(attr) = attribute,
                   let identifier = attr.attributeName.as(IdentifierTypeSyntax.self)
@@ -44,7 +40,7 @@ public struct StorageRelationshipsMacro: MemberMacro {
             return []
         }
 
-        // 2. Pull the item type out of the sibling @Storage(Item.self) attribute.
+        // Pull the item type out of the sibling @Storage(Item.self) attribute.
         guard let itemTypeName = storageItemTypeName(from: declaration) else {
             // @Storage's own macro already diagnoses a malformed argument.
             return []
@@ -112,8 +108,8 @@ public struct StorageRelationshipsMacro: MemberMacro {
 
         guard !sawError else { return [] }
 
-        // 3. Escape hatch, symmetric with @Storage's own: don't regenerate
-        //    members already written by hand. Matched by full signature.
+        // Escape hatch, symmetric with @Storage's own: don't regenerate
+        // members already written by hand. Matched by full signature.
         let existingPropertyNames = existingStoredPropertyNames(in: declaration)
         let existingFunctionSignatures = existingFunctionSignatures(in: declaration)
 
@@ -127,32 +123,22 @@ public struct StorageRelationshipsMacro: MemberMacro {
 
         var members: [DeclSyntax] = []
 
-        // 4. Storage property per relationship — `var by<Parent>Id: [Parent.ID: Item.ID]`.
+        // Storage property per relationship — `var by<Parent>Id: [Parent.ID: Item.ID]`.
         for relationship in relationships where !existingPropertyNames.contains(relationship.propertyName) {
             members.append(DeclSyntax(stringLiteral:
                 "var \(relationship.propertyName): [\(relationship.parentTypeName).ID: \(itemTypeName).ID] = [:]"
             ))
         }
 
-        // 5. Combined reduceRelationships(_:) — composes with @Storage's
-        //    default: branch without colliding with a user-written reduceCustom(_:).
+        // Combined reduceRelationships(_:) — composes with @Storage's
+        // default: branch without colliding with a user-written reduceCustom(_:).
+        // Only DidLoadNestedItem is generated; bulk ByParents load is out of
+        // scope — see the doc comment on `StorageRelationships` for why.
         //
-        //    Only Actions.DidLoadNestedItem<ParentId, Nested> is generated here —
-        //    it's the one confirmed to exist in UDFMacros/UDF's own Actions.swift.
-        //    A bulk "by parents" load is deliberately NOT generated: that action
-        //    (however it's named/shaped) lives at the app level, not the framework
-        //    level, and its shape isn't standardized across apps — generating a
-        //    reference to it would break compilation wherever it doesn't exist or
-        //    doesn't match. If a relationship needs bulk-load handling, add that
-        //    case by hand in reduceCustom(_:), which still sees byId/by<Parent>Id.
-        //
-        //    Built as a flat line array + single DeclSyntax(stringLiteral:) rather
-        //    than a multi-line \(raw:) interpolation embedded inside more literal
-        //    template text — the latter caused a real indentation bug (default:/
-        //    break picked up extra leading spaces) since a multi-line raw
-        //    interpolation followed by more outer-literal lines in the same
-        //    triple-quote doesn't compose the way a single self-contained literal
-        //    does (which is how @Storage's own reduce() cases are written).
+        // Built as a flat line array + single DeclSyntax(stringLiteral:)
+        // rather than a multi-line \(raw:) interpolation followed by more
+        // literal text in the same triple-quote — the latter doesn't
+        // reindent predictably (see StorageMacro's identical fix).
         var reduceRelationshipsLines: [String] = [
             "mutating func reduceRelationships(_ action: some Action) {",
             "    switch action {",
@@ -169,7 +155,7 @@ public struct StorageRelationshipsMacro: MemberMacro {
         reduceRelationshipsLines.append("}")
         members.append(DeclSyntax(stringLiteral: reduceRelationshipsLines.joined(separator: "\n")))
 
-        // 6. Accessor per relationship — overload of `<item>By(...)`, matching
+        // Accessor per relationship — overload of `<item>By(...)`, matching
         //    @Storage's own accessor base name (e.g. `restaurantBy(id:)`).
         //    Returns Item.ID?, matching the hand-written accessors.
         let accessorBaseName = "\(lowerCamelCase(itemTypeName))By"

--- a/Sources/UDFMacrosMacros/StorageRelationshipsMacro.swift
+++ b/Sources/UDFMacrosMacros/StorageRelationshipsMacro.swift
@@ -136,10 +136,10 @@ public struct StorageRelationshipsMacro: MemberMacro {
         let existingPropertyNames = existingStoredPropertyNames(in: declaration)
         let existingFunctionSignatures = existingFunctionSignatures(in: declaration)
 
-        if existingFunctionSignatures.contains("reduceRelationships(_)") {
+        if existingFunctionSignatures.contains("_reduceRelationships(_)") {
             context.diagnose(Diagnostic(
                 node: node,
-                message: StorageRelationshipsDiagnostic.alreadyDeclared("reduceRelationships(_:)")
+                message: StorageRelationshipsDiagnostic.alreadyDeclared("_reduceRelationships(_:)")
             ))
             return []
         }
@@ -160,9 +160,9 @@ public struct StorageRelationshipsMacro: MemberMacro {
             ))
         }
 
-        // reduceRelationships(_:) — both kinds combined into one switch.
+        // _reduceRelationships(_:) — both kinds combined into one switch.
         var reduceRelationshipsLines: [String] = [
-            "mutating func reduceRelationships(_ action: some Action) {",
+            "mutating func _reduceRelationships(_ action: some Action) {",
             "    switch action {",
         ]
         for relationship in hasOneRelationships {
@@ -268,7 +268,7 @@ public struct StorageRelationshipsMacro: MemberMacro {
         return names
     }
 
-    /// Matches on name + parameter labels (e.g. "reduceRelationships(_)",
+    /// Matches on name + parameter labels (e.g. "_reduceRelationships(_)",
     /// "restaurantBy(review)") — the same fix already applied once in
     /// @Storage's own escape-hatch check, for the same reason: matching bare
     /// names alone would mistake unrelated overloads for each other.

--- a/Sources/UDFMacrosMacros/StorageRelationshipsMacro.swift
+++ b/Sources/UDFMacrosMacros/StorageRelationshipsMacro.swift
@@ -171,8 +171,15 @@ public struct StorageRelationshipsMacro: MemberMacro {
             reduceRelationshipsLines.append("        \(relationship.propertyName)[action.parentId] = action.item.id")
             reduceRelationshipsLines.append("")
         }
-        // hasMany's three cases — additive (.append), matching the
-        // union convention confirmed in AllDishes/AllReviews.
+        // hasMany's cases — additive (.append), matching the union convention
+        // confirmed in AllDishes/AllReviews. DeleteNestedItem uses the
+        // full-item form only (Actions.DeleteNestedItem<Parent.ID, Item>),
+        // matching the confirmed AllLabels.swift precedent — the ID-only form
+        // seen in AllAudioBookmarks.swift wasn't used as a basis, since that
+        // file also replaces instead of appending on load (a stale convention
+        // predating the .append union behavior confirmed for this macro).
+        // Actions.DidUpdateNestedItem is deliberately not generated: zero
+        // real usages found across Librarius/Wain/FlatPlanet.
         for relationship in hasManyRelationships {
             reduceRelationshipsLines.append("    case let action as Actions.DidLoadNestedItem<\(relationship.parentTypeName).ID, \(itemTypeName)>:")
             reduceRelationshipsLines.append("        byId.insert(item: action.item)")
@@ -189,6 +196,11 @@ public struct StorageRelationshipsMacro: MemberMacro {
             reduceRelationshipsLines.append("            byId.insert(items: children)")
             reduceRelationshipsLines.append("            \(relationship.propertyName).append(children.ids, by: parentId)")
             reduceRelationshipsLines.append("        }")
+            reduceRelationshipsLines.append("")
+
+            reduceRelationshipsLines.append("    case let action as Actions.DeleteNestedItem<\(relationship.parentTypeName).ID, \(itemTypeName)>:")
+            reduceRelationshipsLines.append("        byId.removeValue(forKey: action.item.id)")
+            reduceRelationshipsLines.append("        \(relationship.propertyName)[action.parentId]?.remove(action.item.id)")
             reduceRelationshipsLines.append("")
         }
         reduceRelationshipsLines.append("    default:")

--- a/Sources/UDFMacrosMacros/StorageRelationshipsMacro.swift
+++ b/Sources/UDFMacrosMacros/StorageRelationshipsMacro.swift
@@ -113,10 +113,10 @@ public struct StorageRelationshipsMacro: MemberMacro {
         let existingPropertyNames = existingStoredPropertyNames(in: declaration)
         let existingFunctionSignatures = existingFunctionSignatures(in: declaration)
 
-        if existingFunctionSignatures.contains("reduceRelationships(_)") {
+        if existingFunctionSignatures.contains("_reduceRelationships(_)") {
             context.diagnose(Diagnostic(
                 node: node,
-                message: StorageRelationshipsDiagnostic.alreadyDeclared("reduceRelationships(_:)")
+                message: StorageRelationshipsDiagnostic.alreadyDeclared("_reduceRelationships(_:)")
             ))
             return []
         }
@@ -130,7 +130,7 @@ public struct StorageRelationshipsMacro: MemberMacro {
             ))
         }
 
-        // Combined reduceRelationships(_:) — composes with @Storage's
+        // Combined _reduceRelationships(_:) — composes with @Storage's
         // default: branch without colliding with a user-written reduceCustom(_:).
         // Only DidLoadNestedItem is generated; bulk ByParents load is out of
         // scope — see the doc comment on `StorageRelationships` for why.
@@ -139,21 +139,21 @@ public struct StorageRelationshipsMacro: MemberMacro {
         // rather than a multi-line \(raw:) interpolation followed by more
         // literal text in the same triple-quote — the latter doesn't
         // reindent predictably (see StorageMacro's identical fix).
-        var reduceRelationshipsLines: [String] = [
-            "mutating func reduceRelationships(_ action: some Action) {",
+        var _reduceRelationshipsLines: [String] = [
+            "mutating func _reduceRelationships(_ action: some Action) {",
             "    switch action {",
         ]
         for relationship in relationships {
-            reduceRelationshipsLines.append("    case let action as Actions.DidLoadNestedItem<\(relationship.parentTypeName).ID, \(itemTypeName)>:")
-            reduceRelationshipsLines.append("        byId.insert(item: action.item)")
-            reduceRelationshipsLines.append("        \(relationship.propertyName)[action.parentId] = action.item.id")
-            reduceRelationshipsLines.append("")
+            _reduceRelationshipsLines.append("    case let action as Actions.DidLoadNestedItem<\(relationship.parentTypeName).ID, \(itemTypeName)>:")
+            _reduceRelationshipsLines.append("        byId.insert(item: action.item)")
+            _reduceRelationshipsLines.append("        \(relationship.propertyName)[action.parentId] = action.item.id")
+            _reduceRelationshipsLines.append("")
         }
-        reduceRelationshipsLines.append("    default:")
-        reduceRelationshipsLines.append("        break")
-        reduceRelationshipsLines.append("    }")
-        reduceRelationshipsLines.append("}")
-        members.append(DeclSyntax(stringLiteral: reduceRelationshipsLines.joined(separator: "\n")))
+        _reduceRelationshipsLines.append("    default:")
+        _reduceRelationshipsLines.append("        break")
+        _reduceRelationshipsLines.append("    }")
+        _reduceRelationshipsLines.append("}")
+        members.append(DeclSyntax(stringLiteral: _reduceRelationshipsLines.joined(separator: "\n")))
 
         // Accessor per relationship — overload of `<item>By(...)`, matching
         //    @Storage's own accessor base name (e.g. `restaurantBy(id:)`).
@@ -211,7 +211,7 @@ public struct StorageRelationshipsMacro: MemberMacro {
         return names
     }
 
-    /// Matches on name + parameter labels (e.g. "reduceRelationships(_)",
+    /// Matches on name + parameter labels (e.g. "_reduceRelationships(_)",
     /// "restaurantBy(review)") — the same fix already applied once in
     /// @Storage's own escape-hatch check, for the same reason: matching bare
     /// names alone would mistake unrelated overloads for each other.

--- a/Sources/UDFMacrosMacros/UDFMacrosPlugin.swift
+++ b/Sources/UDFMacrosMacros/UDFMacrosPlugin.swift
@@ -9,6 +9,7 @@ struct UDFMacrosPlugin: CompilerPlugin {
         AutoEquatableMacro.self,
         AutoHashableMacro.self,
         SensitiveFieldMacro.self,
-        SensitiveDataMacro.self
+        SensitiveDataMacro.self,
+        StorageMacro.self,
     ]
 }

--- a/Sources/UDFMacrosMacros/UDFMacrosPlugin.swift
+++ b/Sources/UDFMacrosMacros/UDFMacrosPlugin.swift
@@ -11,5 +11,6 @@ struct UDFMacrosPlugin: CompilerPlugin {
         SensitiveFieldMacro.self,
         SensitiveDataMacro.self,
         StorageMacro.self,
+        StorageRelationshipsMacro.self,
     ]
 }

--- a/Tests/UDFMacrosTests/UDFMacrosTests.swift
+++ b/Tests/UDFMacrosTests/UDFMacrosTests.swift
@@ -6,1509 +6,1735 @@ import XCTest
 
 // Macro implementations build for the host, so the corresponding module is not available when cross-compiling. Cross-compiled tests may still make use of the macro itself in end-to-end tests.
 #if canImport(UDFMacrosMacros)
-import UDFMacrosMacros
+    import UDFMacrosMacros
 
-let testMacros: [String: Macro.Type] = [
-    "AutoEquatable": AutoEquatableMacro.self,
-    "AutoHashable": AutoHashableMacro.self,
-]
+    let testMacros: [String: Macro.Type] = [
+        "AutoEquatable": AutoEquatableMacro.self,
+        "AutoHashable": AutoHashableMacro.self,
+        "Storage": StorageMacro.self,
+    ]
 #endif
 
 final class UDFMacrosTests: XCTestCase {
     func testAutoEquatableForEnum() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable enum TestEnum {
-                case congratulations(Command)
-                case analytics(Wish.ID)
-                case addVideoFeedback(presentAddPhotoFeedback: Command)
-                case addPhotoFeedback(wishId: Wish.ID)
-                case additionalPhotosZoomed(selectedPhoto: S3MediaResource, photos: [S3MediaResource])
-                case comments(presentation: WishDetailsPresentationType, wishId: Wish.ID)
-                case wishmates(Wish.ID)
-                case editWishFeedback(wishFeedback: WishFeedback)
-                case boosts(Wish.ID)
-            }
-            """#,
-            expandedSource: #"""
-            enum TestEnum {
-                case congratulations(Command)
-                case analytics(Wish.ID)
-                case addVideoFeedback(presentAddPhotoFeedback: Command)
-                case addPhotoFeedback(wishId: Wish.ID)
-                case additionalPhotosZoomed(selectedPhoto: S3MediaResource, photos: [S3MediaResource])
-                case comments(presentation: WishDetailsPresentationType, wishId: Wish.ID)
-                case wishmates(Wish.ID)
-                case editWishFeedback(wishFeedback: WishFeedback)
-                case boosts(Wish.ID)
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable enum TestEnum {
+                    case congratulations(Command)
+                    case analytics(Wish.ID)
+                    case addVideoFeedback(presentAddPhotoFeedback: Command)
+                    case addPhotoFeedback(wishId: Wish.ID)
+                    case additionalPhotosZoomed(selectedPhoto: S3MediaResource, photos: [S3MediaResource])
+                    case comments(presentation: WishDetailsPresentationType, wishId: Wish.ID)
+                    case wishmates(Wish.ID)
+                    case editWishFeedback(wishFeedback: WishFeedback)
+                    case boosts(Wish.ID)
+                }
+                """#,
+                expandedSource: #"""
+                enum TestEnum {
+                    case congratulations(Command)
+                    case analytics(Wish.ID)
+                    case addVideoFeedback(presentAddPhotoFeedback: Command)
+                    case addPhotoFeedback(wishId: Wish.ID)
+                    case additionalPhotosZoomed(selectedPhoto: S3MediaResource, photos: [S3MediaResource])
+                    case comments(presentation: WishDetailsPresentationType, wishId: Wish.ID)
+                    case wishmates(Wish.ID)
+                    case editWishFeedback(wishFeedback: WishFeedback)
+                    case boosts(Wish.ID)
+                }
 
-            extension TestEnum: Equatable {
-                static func ==(lhs: TestEnum, rhs: TestEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case let (.congratulations(lhs0), .congratulations(rhs0)):
-                        lhs0 == rhs0
-                    case let (.analytics(lhs0), .analytics(rhs0)):
-                        lhs0 == rhs0
-                    case let (.addVideoFeedback(lhs0), .addVideoFeedback(rhs0)):
-                        lhs0 == rhs0
-                    case let (.addPhotoFeedback(lhs0), .addPhotoFeedback(rhs0)):
-                        lhs0 == rhs0
-                    case let (.additionalPhotosZoomed(lhs0, lhs1), .additionalPhotosZoomed(rhs0, rhs1)):
-                        lhs0 == rhs0 && lhs1 == rhs1
-                    case let (.comments(lhs0, lhs1), .comments(rhs0, rhs1)):
-                        lhs0 == rhs0 && lhs1 == rhs1
-                    case let (.wishmates(lhs0), .wishmates(rhs0)):
-                        lhs0 == rhs0
-                    case let (.editWishFeedback(lhs0), .editWishFeedback(rhs0)):
-                        lhs0 == rhs0
-                    case let (.boosts(lhs0), .boosts(rhs0)):
-                        lhs0 == rhs0
-                    default:
-                        false
+                extension TestEnum: Equatable {
+                    static func ==(lhs: TestEnum, rhs: TestEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case let (.congratulations(lhs0), .congratulations(rhs0)):
+                            lhs0 == rhs0
+                        case let (.analytics(lhs0), .analytics(rhs0)):
+                            lhs0 == rhs0
+                        case let (.addVideoFeedback(lhs0), .addVideoFeedback(rhs0)):
+                            lhs0 == rhs0
+                        case let (.addPhotoFeedback(lhs0), .addPhotoFeedback(rhs0)):
+                            lhs0 == rhs0
+                        case let (.additionalPhotosZoomed(lhs0, lhs1), .additionalPhotosZoomed(rhs0, rhs1)):
+                            lhs0 == rhs0 && lhs1 == rhs1
+                        case let (.comments(lhs0, lhs1), .comments(rhs0, rhs1)):
+                            lhs0 == rhs0 && lhs1 == rhs1
+                        case let (.wishmates(lhs0), .wishmates(rhs0)):
+                            lhs0 == rhs0
+                        case let (.editWishFeedback(lhs0), .editWishFeedback(rhs0)):
+                            lhs0 == rhs0
+                        case let (.boosts(lhs0), .boosts(rhs0)):
+                            lhs0 == rhs0
+                        default:
+                            false
+                        }
                     }
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableForStruct() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable struct TestStruct {
-                let id: Int
-                let value: Int
-                let model: Model
-                let modelID: Model.ID
-            }
-            """#,
-            expandedSource: #"""
-            struct TestStruct {
-                let id: Int
-                let value: Int
-                let model: Model
-                let modelID: Model.ID
-            }
-            
-            extension TestStruct: Equatable {
-                static func ==(lhs: TestStruct, rhs: TestStruct) -> Bool {
-                    lhs.id == rhs.id && lhs.value == rhs.value && lhs.model == rhs.model && lhs.modelID == rhs.modelID
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable struct TestStruct {
+                    let id: Int
+                    let value: Int
+                    let model: Model
+                    let modelID: Model.ID
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                expandedSource: #"""
+                struct TestStruct {
+                    let id: Int
+                    let value: Int
+                    let model: Model
+                    let modelID: Model.ID
+                }
+
+                extension TestStruct: Equatable {
+                    static func ==(lhs: TestStruct, rhs: TestStruct) -> Bool {
+                        lhs.id == rhs.id && lhs.value == rhs.value && lhs.model == rhs.model && lhs.modelID == rhs.modelID
+                    }
+                }
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableForClass() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable class TestClass {
-                let id: Int
-                let value: Int
-                let model: Model
-                let modelID: Model.ID
-            }
-            """#,
-            expandedSource: #"""
-            class TestClass {
-                let id: Int
-                let value: Int
-                let model: Model
-                let modelID: Model.ID
-            }
-
-            extension TestClass: Equatable {
-                static func ==(lhs: TestClass, rhs: TestClass) -> Bool {
-                    lhs.id == rhs.id && lhs.value == rhs.value && lhs.model == rhs.model && lhs.modelID == rhs.modelID
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable class TestClass {
+                    let id: Int
+                    let value: Int
+                    let model: Model
+                    let modelID: Model.ID
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                expandedSource: #"""
+                class TestClass {
+                    let id: Int
+                    let value: Int
+                    let model: Model
+                    let modelID: Model.ID
+                }
+
+                extension TestClass: Equatable {
+                    static func ==(lhs: TestClass, rhs: TestClass) -> Bool {
+                        lhs.id == rhs.id && lhs.value == rhs.value && lhs.model == rhs.model && lhs.modelID == rhs.modelID
+                    }
+                }
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableForStructWithArraysAndOptionals() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable struct TestStruct {
-                let ids: [Int]
-                let names: [String]
-                let optionalId: Int?
-                let optionalName: String?
-                let resources: [S3MediaResource]
-                let nonEquatableArray: [Command]
-                let uuid: UUID
-                let date: Date
-            }
-            """#,
-            expandedSource: #"""
-            struct TestStruct {
-                let ids: [Int]
-                let names: [String]
-                let optionalId: Int?
-                let optionalName: String?
-                let resources: [S3MediaResource]
-                let nonEquatableArray: [Command]
-                let uuid: UUID
-                let date: Date
-            }
-            
-            extension TestStruct: Equatable {
-                static func ==(lhs: TestStruct, rhs: TestStruct) -> Bool {
-                    lhs.ids == rhs.ids && lhs.names == rhs.names && lhs.optionalId == rhs.optionalId && lhs.optionalName == rhs.optionalName && lhs.resources == rhs.resources && lhs.nonEquatableArray == rhs.nonEquatableArray && lhs.uuid == rhs.uuid && lhs.date == rhs.date
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable struct TestStruct {
+                    let ids: [Int]
+                    let names: [String]
+                    let optionalId: Int?
+                    let optionalName: String?
+                    let resources: [S3MediaResource]
+                    let nonEquatableArray: [Command]
+                    let uuid: UUID
+                    let date: Date
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                expandedSource: #"""
+                struct TestStruct {
+                    let ids: [Int]
+                    let names: [String]
+                    let optionalId: Int?
+                    let optionalName: String?
+                    let resources: [S3MediaResource]
+                    let nonEquatableArray: [Command]
+                    let uuid: UUID
+                    let date: Date
+                }
+
+                extension TestStruct: Equatable {
+                    static func ==(lhs: TestStruct, rhs: TestStruct) -> Bool {
+                        lhs.ids == rhs.ids && lhs.names == rhs.names && lhs.optionalId == rhs.optionalId && lhs.optionalName == rhs.optionalName && lhs.resources == rhs.resources && lhs.nonEquatableArray == rhs.nonEquatableArray && lhs.uuid == rhs.uuid && lhs.date == rhs.date
+                    }
+                }
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableForStructWithCollections() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable struct TestStruct {
-                let stringSet: Set<String>
-                let intDict: Dictionary<String, Int>
-                let tuple: (Int, String, Bool)
-                let nonEquatableTuple: (Command, String)
-            }
-            """#,
-            expandedSource: #"""
-            struct TestStruct {
-                let stringSet: Set<String>
-                let intDict: Dictionary<String, Int>
-                let tuple: (Int, String, Bool)
-                let nonEquatableTuple: (Command, String)
-            }
-            
-            extension TestStruct: Equatable {
-                static func ==(lhs: TestStruct, rhs: TestStruct) -> Bool {
-                    lhs.stringSet == rhs.stringSet && lhs.intDict == rhs.intDict && lhs.tuple == rhs.tuple && lhs.nonEquatableTuple == rhs.nonEquatableTuple
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable struct TestStruct {
+                    let stringSet: Set<String>
+                    let intDict: Dictionary<String, Int>
+                    let tuple: (Int, String, Bool)
+                    let nonEquatableTuple: (Command, String)
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                expandedSource: #"""
+                struct TestStruct {
+                    let stringSet: Set<String>
+                    let intDict: Dictionary<String, Int>
+                    let tuple: (Int, String, Bool)
+                    let nonEquatableTuple: (Command, String)
+                }
+
+                extension TestStruct: Equatable {
+                    static func ==(lhs: TestStruct, rhs: TestStruct) -> Bool {
+                        lhs.stringSet == rhs.stringSet && lhs.intDict == rhs.intDict && lhs.tuple == rhs.tuple && lhs.nonEquatableTuple == rhs.nonEquatableTuple
+                    }
+                }
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableForEnumWithMixedTypes() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable enum TestEnum {
-                case withArrays(ids: [Int], names: [String])
-                case withOptionals(id: Int?, name: String?)
-                case withSets(numbers: Set<Int>, strings: Set<String>)
-                case withDictionary(mapping: Dictionary<String, Int>)
-                case withTuple(data: (Int, String, Bool))
-                case withMixed(id: Int, command: Command, resources: [S3MediaResource])
-                case withUUID(uuid: UUID, date: Date)
-            }
-            """#,
-            expandedSource: #"""
-            enum TestEnum {
-                case withArrays(ids: [Int], names: [String])
-                case withOptionals(id: Int?, name: String?)
-                case withSets(numbers: Set<Int>, strings: Set<String>)
-                case withDictionary(mapping: Dictionary<String, Int>)
-                case withTuple(data: (Int, String, Bool))
-                case withMixed(id: Int, command: Command, resources: [S3MediaResource])
-                case withUUID(uuid: UUID, date: Date)
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable enum TestEnum {
+                    case withArrays(ids: [Int], names: [String])
+                    case withOptionals(id: Int?, name: String?)
+                    case withSets(numbers: Set<Int>, strings: Set<String>)
+                    case withDictionary(mapping: Dictionary<String, Int>)
+                    case withTuple(data: (Int, String, Bool))
+                    case withMixed(id: Int, command: Command, resources: [S3MediaResource])
+                    case withUUID(uuid: UUID, date: Date)
+                }
+                """#,
+                expandedSource: #"""
+                enum TestEnum {
+                    case withArrays(ids: [Int], names: [String])
+                    case withOptionals(id: Int?, name: String?)
+                    case withSets(numbers: Set<Int>, strings: Set<String>)
+                    case withDictionary(mapping: Dictionary<String, Int>)
+                    case withTuple(data: (Int, String, Bool))
+                    case withMixed(id: Int, command: Command, resources: [S3MediaResource])
+                    case withUUID(uuid: UUID, date: Date)
+                }
 
-            extension TestEnum: Equatable {
-                static func ==(lhs: TestEnum, rhs: TestEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case let (.withArrays(lhs0, lhs1), .withArrays(rhs0, rhs1)):
-                        lhs0 == rhs0 && lhs1 == rhs1
-                    case let (.withOptionals(lhs0, lhs1), .withOptionals(rhs0, rhs1)):
-                        lhs0 == rhs0 && lhs1 == rhs1
-                    case let (.withSets(lhs0, lhs1), .withSets(rhs0, rhs1)):
-                        lhs0 == rhs0 && lhs1 == rhs1
-                    case let (.withDictionary(lhs0), .withDictionary(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withTuple(lhs0), .withTuple(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withMixed(lhs0, lhs1, lhs2), .withMixed(rhs0, rhs1, rhs2)):
-                        lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2
-                    case let (.withUUID(lhs0, lhs1), .withUUID(rhs0, rhs1)):
-                        lhs0 == rhs0 && lhs1 == rhs1
-                    default:
-                        false
+                extension TestEnum: Equatable {
+                    static func ==(lhs: TestEnum, rhs: TestEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case let (.withArrays(lhs0, lhs1), .withArrays(rhs0, rhs1)):
+                            lhs0 == rhs0 && lhs1 == rhs1
+                        case let (.withOptionals(lhs0, lhs1), .withOptionals(rhs0, rhs1)):
+                            lhs0 == rhs0 && lhs1 == rhs1
+                        case let (.withSets(lhs0, lhs1), .withSets(rhs0, rhs1)):
+                            lhs0 == rhs0 && lhs1 == rhs1
+                        case let (.withDictionary(lhs0), .withDictionary(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withTuple(lhs0), .withTuple(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withMixed(lhs0, lhs1, lhs2), .withMixed(rhs0, rhs1, rhs2)):
+                            lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2
+                        case let (.withUUID(lhs0, lhs1), .withUUID(rhs0, rhs1)):
+                            lhs0 == rhs0 && lhs1 == rhs1
+                        default:
+                            false
+                        }
                     }
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableForEnumWithCustomTypes() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable enum MyCustomEnum {
-                case withPrimitives(id: Int, name: String, active: Bool)
-                case withCustomStruct(data: MyCustomStruct)
-                case withMixed(id: Int, struct: MyCustomStruct, count: Int)
-                case withArray(items: [MyCustomStruct])
-                case withOptional(item: MyCustomStruct?)
-                case noAssociatedValues
-            }
-            """#,
-            expandedSource: #"""
-            enum MyCustomEnum {
-                case withPrimitives(id: Int, name: String, active: Bool)
-                case withCustomStruct(data: MyCustomStruct)
-                case withMixed(id: Int, struct: MyCustomStruct, count: Int)
-                case withArray(items: [MyCustomStruct])
-                case withOptional(item: MyCustomStruct?)
-                case noAssociatedValues
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable enum MyCustomEnum {
+                    case withPrimitives(id: Int, name: String, active: Bool)
+                    case withCustomStruct(data: MyCustomStruct)
+                    case withMixed(id: Int, struct: MyCustomStruct, count: Int)
+                    case withArray(items: [MyCustomStruct])
+                    case withOptional(item: MyCustomStruct?)
+                    case noAssociatedValues
+                }
+                """#,
+                expandedSource: #"""
+                enum MyCustomEnum {
+                    case withPrimitives(id: Int, name: String, active: Bool)
+                    case withCustomStruct(data: MyCustomStruct)
+                    case withMixed(id: Int, struct: MyCustomStruct, count: Int)
+                    case withArray(items: [MyCustomStruct])
+                    case withOptional(item: MyCustomStruct?)
+                    case noAssociatedValues
+                }
 
-            extension MyCustomEnum: Equatable {
-                static func ==(lhs: MyCustomEnum, rhs: MyCustomEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case let (.withPrimitives(lhs0, lhs1, lhs2), .withPrimitives(rhs0, rhs1, rhs2)):
-                        lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2
-                    case let (.withCustomStruct(lhs0), .withCustomStruct(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withMixed(lhs0, lhs1, lhs2), .withMixed(rhs0, rhs1, rhs2)):
-                        lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2
-                    case let (.withArray(lhs0), .withArray(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withOptional(lhs0), .withOptional(rhs0)):
-                        lhs0 == rhs0
-                    case (.noAssociatedValues, .noAssociatedValues):
-                        true
-                    default:
-                        false
+                extension MyCustomEnum: Equatable {
+                    static func ==(lhs: MyCustomEnum, rhs: MyCustomEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case let (.withPrimitives(lhs0, lhs1, lhs2), .withPrimitives(rhs0, rhs1, rhs2)):
+                            lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2
+                        case let (.withCustomStruct(lhs0), .withCustomStruct(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withMixed(lhs0, lhs1, lhs2), .withMixed(rhs0, rhs1, rhs2)):
+                            lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2
+                        case let (.withArray(lhs0), .withArray(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withOptional(lhs0), .withOptional(rhs0)):
+                            lhs0 == rhs0
+                        case (.noAssociatedValues, .noAssociatedValues):
+                            true
+                        default:
+                            false
+                        }
                     }
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableWithSimplifiedApproach() throws {
         #if canImport(UDFMacrosMacros)
-        // Test that the simplified approach generates comparisons for ALL types
-        // without any hardcoded type checking
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable enum TestEnum {
-                case withUnknownType(CustomType)
-                case withAnotherUnknownType(SomeOtherType)
-                case withComplexNested([[[CustomType]]])
-                case withTuple((CustomType, AnotherType, ThirdType))
-                case withOptional(CustomType?)
-                case withSet(Set<CustomType>)
-                case withDictionary(Dictionary<CustomType, AnotherType>)
-            }
-            """#,
-            expandedSource: #"""
-            enum TestEnum {
-                case withUnknownType(CustomType)
-                case withAnotherUnknownType(SomeOtherType)
-                case withComplexNested([[[CustomType]]])
-                case withTuple((CustomType, AnotherType, ThirdType))
-                case withOptional(CustomType?)
-                case withSet(Set<CustomType>)
-                case withDictionary(Dictionary<CustomType, AnotherType>)
-            }
+            // Test that the simplified approach generates comparisons for ALL types
+            // without any hardcoded type checking
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable enum TestEnum {
+                    case withUnknownType(CustomType)
+                    case withAnotherUnknownType(SomeOtherType)
+                    case withComplexNested([[[CustomType]]])
+                    case withTuple((CustomType, AnotherType, ThirdType))
+                    case withOptional(CustomType?)
+                    case withSet(Set<CustomType>)
+                    case withDictionary(Dictionary<CustomType, AnotherType>)
+                }
+                """#,
+                expandedSource: #"""
+                enum TestEnum {
+                    case withUnknownType(CustomType)
+                    case withAnotherUnknownType(SomeOtherType)
+                    case withComplexNested([[[CustomType]]])
+                    case withTuple((CustomType, AnotherType, ThirdType))
+                    case withOptional(CustomType?)
+                    case withSet(Set<CustomType>)
+                    case withDictionary(Dictionary<CustomType, AnotherType>)
+                }
 
-            extension TestEnum: Equatable {
-                static func ==(lhs: TestEnum, rhs: TestEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case let (.withUnknownType(lhs0), .withUnknownType(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withAnotherUnknownType(lhs0), .withAnotherUnknownType(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withComplexNested(lhs0), .withComplexNested(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withTuple(lhs0), .withTuple(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withOptional(lhs0), .withOptional(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withSet(lhs0), .withSet(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withDictionary(lhs0), .withDictionary(rhs0)):
-                        lhs0 == rhs0
-                    default:
-                        false
+                extension TestEnum: Equatable {
+                    static func ==(lhs: TestEnum, rhs: TestEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case let (.withUnknownType(lhs0), .withUnknownType(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withAnotherUnknownType(lhs0), .withAnotherUnknownType(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withComplexNested(lhs0), .withComplexNested(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withTuple(lhs0), .withTuple(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withOptional(lhs0), .withOptional(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withSet(lhs0), .withSet(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withDictionary(lhs0), .withDictionary(rhs0)):
+                            lhs0 == rhs0
+                        default:
+                            false
+                        }
                     }
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableForEnumWithNoAssociatedValues() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable enum SimpleEnum {
-                case first
-                case second
-                case third
-            }
-            """#,
-            expandedSource: #"""
-            enum SimpleEnum {
-                case first
-                case second
-                case third
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable enum SimpleEnum {
+                    case first
+                    case second
+                    case third
+                }
+                """#,
+                expandedSource: #"""
+                enum SimpleEnum {
+                    case first
+                    case second
+                    case third
+                }
 
-            extension SimpleEnum: Equatable {
-                static func ==(lhs: SimpleEnum, rhs: SimpleEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case (.first, .first):
-                        true
-                    case (.second, .second):
-                        true
-                    case (.third, .third):
-                        true
-                    default:
-                        false
+                extension SimpleEnum: Equatable {
+                    static func ==(lhs: SimpleEnum, rhs: SimpleEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case (.first, .first):
+                            true
+                        case (.second, .second):
+                            true
+                        case (.third, .third):
+                            true
+                        default:
+                            false
+                        }
                     }
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableForEnumWithAllPrimitiveTypes() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable enum PrimitiveEnum {
-                case withInt(Int)
-                case withString(String)
-                case withBool(Bool)
-                case withDouble(Double)
-                case withFloat(Float)
-                case withCharacter(Character)
-                case withInt8(Int8)
-                case withInt16(Int16)
-                case withInt32(Int32)
-                case withInt64(Int64)
-                case withUInt(UInt)
-                case withUInt8(UInt8)
-                case withUInt16(UInt16)
-                case withUInt32(UInt32)
-                case withUInt64(UInt64)
-            }
-            """#,
-            expandedSource: #"""
-            enum PrimitiveEnum {
-                case withInt(Int)
-                case withString(String)
-                case withBool(Bool)
-                case withDouble(Double)
-                case withFloat(Float)
-                case withCharacter(Character)
-                case withInt8(Int8)
-                case withInt16(Int16)
-                case withInt32(Int32)
-                case withInt64(Int64)
-                case withUInt(UInt)
-                case withUInt8(UInt8)
-                case withUInt16(UInt16)
-                case withUInt32(UInt32)
-                case withUInt64(UInt64)
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable enum PrimitiveEnum {
+                    case withInt(Int)
+                    case withString(String)
+                    case withBool(Bool)
+                    case withDouble(Double)
+                    case withFloat(Float)
+                    case withCharacter(Character)
+                    case withInt8(Int8)
+                    case withInt16(Int16)
+                    case withInt32(Int32)
+                    case withInt64(Int64)
+                    case withUInt(UInt)
+                    case withUInt8(UInt8)
+                    case withUInt16(UInt16)
+                    case withUInt32(UInt32)
+                    case withUInt64(UInt64)
+                }
+                """#,
+                expandedSource: #"""
+                enum PrimitiveEnum {
+                    case withInt(Int)
+                    case withString(String)
+                    case withBool(Bool)
+                    case withDouble(Double)
+                    case withFloat(Float)
+                    case withCharacter(Character)
+                    case withInt8(Int8)
+                    case withInt16(Int16)
+                    case withInt32(Int32)
+                    case withInt64(Int64)
+                    case withUInt(UInt)
+                    case withUInt8(UInt8)
+                    case withUInt16(UInt16)
+                    case withUInt32(UInt32)
+                    case withUInt64(UInt64)
+                }
 
-            extension PrimitiveEnum: Equatable {
-                static func ==(lhs: PrimitiveEnum, rhs: PrimitiveEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case let (.withInt(lhs0), .withInt(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withString(lhs0), .withString(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withBool(lhs0), .withBool(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withDouble(lhs0), .withDouble(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withFloat(lhs0), .withFloat(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withCharacter(lhs0), .withCharacter(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withInt8(lhs0), .withInt8(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withInt16(lhs0), .withInt16(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withInt32(lhs0), .withInt32(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withInt64(lhs0), .withInt64(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withUInt(lhs0), .withUInt(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withUInt8(lhs0), .withUInt8(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withUInt16(lhs0), .withUInt16(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withUInt32(lhs0), .withUInt32(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withUInt64(lhs0), .withUInt64(rhs0)):
-                        lhs0 == rhs0
-                    default:
-                        false
+                extension PrimitiveEnum: Equatable {
+                    static func ==(lhs: PrimitiveEnum, rhs: PrimitiveEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case let (.withInt(lhs0), .withInt(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withString(lhs0), .withString(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withBool(lhs0), .withBool(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withDouble(lhs0), .withDouble(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withFloat(lhs0), .withFloat(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withCharacter(lhs0), .withCharacter(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withInt8(lhs0), .withInt8(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withInt16(lhs0), .withInt16(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withInt32(lhs0), .withInt32(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withInt64(lhs0), .withInt64(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withUInt(lhs0), .withUInt(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withUInt8(lhs0), .withUInt8(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withUInt16(lhs0), .withUInt16(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withUInt32(lhs0), .withUInt32(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withUInt64(lhs0), .withUInt64(rhs0)):
+                            lhs0 == rhs0
+                        default:
+                            false
+                        }
                     }
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableForEnumWithLabeledAssociatedValues() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable enum LabeledEnum {
-                case withSingleLabel(userId: Int)
-                case withMultipleLabels(userId: Int, name: String, active: Bool)
-                case withMixedLabels(Int, name: String, active: Bool)
-                case withComplexLabels(primaryId: UUID, secondaryIds: [Int], metadata: [String: String])
-            }
-            """#,
-            expandedSource: #"""
-            enum LabeledEnum {
-                case withSingleLabel(userId: Int)
-                case withMultipleLabels(userId: Int, name: String, active: Bool)
-                case withMixedLabels(Int, name: String, active: Bool)
-                case withComplexLabels(primaryId: UUID, secondaryIds: [Int], metadata: [String: String])
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable enum LabeledEnum {
+                    case withSingleLabel(userId: Int)
+                    case withMultipleLabels(userId: Int, name: String, active: Bool)
+                    case withMixedLabels(Int, name: String, active: Bool)
+                    case withComplexLabels(primaryId: UUID, secondaryIds: [Int], metadata: [String: String])
+                }
+                """#,
+                expandedSource: #"""
+                enum LabeledEnum {
+                    case withSingleLabel(userId: Int)
+                    case withMultipleLabels(userId: Int, name: String, active: Bool)
+                    case withMixedLabels(Int, name: String, active: Bool)
+                    case withComplexLabels(primaryId: UUID, secondaryIds: [Int], metadata: [String: String])
+                }
 
-            extension LabeledEnum: Equatable {
-                static func ==(lhs: LabeledEnum, rhs: LabeledEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case let (.withSingleLabel(lhs0), .withSingleLabel(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withMultipleLabels(lhs0, lhs1, lhs2), .withMultipleLabels(rhs0, rhs1, rhs2)):
-                        lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2
-                    case let (.withMixedLabels(lhs0, lhs1, lhs2), .withMixedLabels(rhs0, rhs1, rhs2)):
-                        lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2
-                    case let (.withComplexLabels(lhs0, lhs1, lhs2), .withComplexLabels(rhs0, rhs1, rhs2)):
-                        lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2
-                    default:
-                        false
+                extension LabeledEnum: Equatable {
+                    static func ==(lhs: LabeledEnum, rhs: LabeledEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case let (.withSingleLabel(lhs0), .withSingleLabel(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withMultipleLabels(lhs0, lhs1, lhs2), .withMultipleLabels(rhs0, rhs1, rhs2)):
+                            lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2
+                        case let (.withMixedLabels(lhs0, lhs1, lhs2), .withMixedLabels(rhs0, rhs1, rhs2)):
+                            lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2
+                        case let (.withComplexLabels(lhs0, lhs1, lhs2), .withComplexLabels(rhs0, rhs1, rhs2)):
+                            lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2
+                        default:
+                            false
+                        }
                     }
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableForEnumWithNestedCollections() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable enum NestedEnum {
-                case withNestedArrays([[Int]])
-                case withTripleNested([[[String]]])
-                case withNestedOptionals([Int?])
-                case withOptionalArrays([Int]?)
-                case withNestedSets(Set<Set<String>>)
-                case withNestedDictionaries([String: [Int: String]])
-                case withComplexNested([String: [Set<Int>]])
-            }
-            """#,
-            expandedSource: #"""
-            enum NestedEnum {
-                case withNestedArrays([[Int]])
-                case withTripleNested([[[String]]])
-                case withNestedOptionals([Int?])
-                case withOptionalArrays([Int]?)
-                case withNestedSets(Set<Set<String>>)
-                case withNestedDictionaries([String: [Int: String]])
-                case withComplexNested([String: [Set<Int>]])
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable enum NestedEnum {
+                    case withNestedArrays([[Int]])
+                    case withTripleNested([[[String]]])
+                    case withNestedOptionals([Int?])
+                    case withOptionalArrays([Int]?)
+                    case withNestedSets(Set<Set<String>>)
+                    case withNestedDictionaries([String: [Int: String]])
+                    case withComplexNested([String: [Set<Int>]])
+                }
+                """#,
+                expandedSource: #"""
+                enum NestedEnum {
+                    case withNestedArrays([[Int]])
+                    case withTripleNested([[[String]]])
+                    case withNestedOptionals([Int?])
+                    case withOptionalArrays([Int]?)
+                    case withNestedSets(Set<Set<String>>)
+                    case withNestedDictionaries([String: [Int: String]])
+                    case withComplexNested([String: [Set<Int>]])
+                }
 
-            extension NestedEnum: Equatable {
-                static func ==(lhs: NestedEnum, rhs: NestedEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case let (.withNestedArrays(lhs0), .withNestedArrays(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withTripleNested(lhs0), .withTripleNested(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withNestedOptionals(lhs0), .withNestedOptionals(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withOptionalArrays(lhs0), .withOptionalArrays(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withNestedSets(lhs0), .withNestedSets(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withNestedDictionaries(lhs0), .withNestedDictionaries(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withComplexNested(lhs0), .withComplexNested(rhs0)):
-                        lhs0 == rhs0
-                    default:
-                        false
+                extension NestedEnum: Equatable {
+                    static func ==(lhs: NestedEnum, rhs: NestedEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case let (.withNestedArrays(lhs0), .withNestedArrays(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withTripleNested(lhs0), .withTripleNested(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withNestedOptionals(lhs0), .withNestedOptionals(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withOptionalArrays(lhs0), .withOptionalArrays(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withNestedSets(lhs0), .withNestedSets(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withNestedDictionaries(lhs0), .withNestedDictionaries(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withComplexNested(lhs0), .withComplexNested(rhs0)):
+                            lhs0 == rhs0
+                        default:
+                            false
+                        }
                     }
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableForEnumWithFoundationTypes() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable enum FoundationEnum {
-                case withUUID(UUID)
-                case withDate(Date)
-                case withURL(URL)
-                case withData(Data)
-                case withDecimal(Decimal)
-                case withFoundationMix(uuid: UUID, date: Date, url: URL)
-            }
-            """#,
-            expandedSource: #"""
-            enum FoundationEnum {
-                case withUUID(UUID)
-                case withDate(Date)
-                case withURL(URL)
-                case withData(Data)
-                case withDecimal(Decimal)
-                case withFoundationMix(uuid: UUID, date: Date, url: URL)
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable enum FoundationEnum {
+                    case withUUID(UUID)
+                    case withDate(Date)
+                    case withURL(URL)
+                    case withData(Data)
+                    case withDecimal(Decimal)
+                    case withFoundationMix(uuid: UUID, date: Date, url: URL)
+                }
+                """#,
+                expandedSource: #"""
+                enum FoundationEnum {
+                    case withUUID(UUID)
+                    case withDate(Date)
+                    case withURL(URL)
+                    case withData(Data)
+                    case withDecimal(Decimal)
+                    case withFoundationMix(uuid: UUID, date: Date, url: URL)
+                }
 
-            extension FoundationEnum: Equatable {
-                static func ==(lhs: FoundationEnum, rhs: FoundationEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case let (.withUUID(lhs0), .withUUID(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withDate(lhs0), .withDate(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withURL(lhs0), .withURL(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withData(lhs0), .withData(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withDecimal(lhs0), .withDecimal(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withFoundationMix(lhs0, lhs1, lhs2), .withFoundationMix(rhs0, rhs1, rhs2)):
-                        lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2
-                    default:
-                        false
+                extension FoundationEnum: Equatable {
+                    static func ==(lhs: FoundationEnum, rhs: FoundationEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case let (.withUUID(lhs0), .withUUID(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withDate(lhs0), .withDate(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withURL(lhs0), .withURL(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withData(lhs0), .withData(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withDecimal(lhs0), .withDecimal(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withFoundationMix(lhs0, lhs1, lhs2), .withFoundationMix(rhs0, rhs1, rhs2)):
+                            lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2
+                        default:
+                            false
+                        }
                     }
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableForEnumWithLongTuples() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable enum TupleEnum {
-                case withTuple2((Int, String))
-                case withTuple3((Int, String, Bool))
-                case withTuple5((Int, String, Bool, Double, Float))
-                case withTuple10((Int, String, Bool, Double, Float, Character, Int8, Int16, Int32, Int64))
-                case withCustomTuple((UUID, Date, CustomType))
-            }
-            """#,
-            expandedSource: #"""
-            enum TupleEnum {
-                case withTuple2((Int, String))
-                case withTuple3((Int, String, Bool))
-                case withTuple5((Int, String, Bool, Double, Float))
-                case withTuple10((Int, String, Bool, Double, Float, Character, Int8, Int16, Int32, Int64))
-                case withCustomTuple((UUID, Date, CustomType))
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable enum TupleEnum {
+                    case withTuple2((Int, String))
+                    case withTuple3((Int, String, Bool))
+                    case withTuple5((Int, String, Bool, Double, Float))
+                    case withTuple10((Int, String, Bool, Double, Float, Character, Int8, Int16, Int32, Int64))
+                    case withCustomTuple((UUID, Date, CustomType))
+                }
+                """#,
+                expandedSource: #"""
+                enum TupleEnum {
+                    case withTuple2((Int, String))
+                    case withTuple3((Int, String, Bool))
+                    case withTuple5((Int, String, Bool, Double, Float))
+                    case withTuple10((Int, String, Bool, Double, Float, Character, Int8, Int16, Int32, Int64))
+                    case withCustomTuple((UUID, Date, CustomType))
+                }
 
-            extension TupleEnum: Equatable {
-                static func ==(lhs: TupleEnum, rhs: TupleEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case let (.withTuple2(lhs0), .withTuple2(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withTuple3(lhs0), .withTuple3(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withTuple5(lhs0), .withTuple5(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withTuple10(lhs0), .withTuple10(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withCustomTuple(lhs0), .withCustomTuple(rhs0)):
-                        lhs0 == rhs0
-                    default:
-                        false
+                extension TupleEnum: Equatable {
+                    static func ==(lhs: TupleEnum, rhs: TupleEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case let (.withTuple2(lhs0), .withTuple2(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withTuple3(lhs0), .withTuple3(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withTuple5(lhs0), .withTuple5(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withTuple10(lhs0), .withTuple10(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withCustomTuple(lhs0), .withCustomTuple(rhs0)):
+                            lhs0 == rhs0
+                        default:
+                            false
+                        }
                     }
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableExcludesVoidAndNever() throws {
         #if canImport(UDFMacrosMacros)
-        // Test that Void and Never types are explicitly excluded from equality comparison
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable enum EdgeCaseEnum {
-                case withNormalType(Int)
-                case withVoidType(Void)
-                case withNeverType(Never)
-                case withMixedTypes(Int, Void, String)
-            }
-            """#,
-            expandedSource: #"""
-            enum EdgeCaseEnum {
-                case withNormalType(Int)
-                case withVoidType(Void)
-                case withNeverType(Never)
-                case withMixedTypes(Int, Void, String)
-            }
+            // Test that Void and Never types are explicitly excluded from equality comparison
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable enum EdgeCaseEnum {
+                    case withNormalType(Int)
+                    case withVoidType(Void)
+                    case withNeverType(Never)
+                    case withMixedTypes(Int, Void, String)
+                }
+                """#,
+                expandedSource: #"""
+                enum EdgeCaseEnum {
+                    case withNormalType(Int)
+                    case withVoidType(Void)
+                    case withNeverType(Never)
+                    case withMixedTypes(Int, Void, String)
+                }
 
-            extension EdgeCaseEnum: Equatable {
-                static func ==(lhs: EdgeCaseEnum, rhs: EdgeCaseEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case let (.withNormalType(lhs0), .withNormalType(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withVoidType(_), .withVoidType(_)):
-                        true
-                    case let (.withNeverType(_), .withNeverType(_)):
-                        true
-                    case let (.withMixedTypes(lhs0, _, lhs2), .withMixedTypes(rhs0, _, rhs2)):
-                        lhs0 == rhs0 && lhs2 == rhs2
-                    default:
-                        false
+                extension EdgeCaseEnum: Equatable {
+                    static func ==(lhs: EdgeCaseEnum, rhs: EdgeCaseEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case let (.withNormalType(lhs0), .withNormalType(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withVoidType(_), .withVoidType(_)):
+                            true
+                        case let (.withNeverType(_), .withNeverType(_)):
+                            true
+                        case let (.withMixedTypes(lhs0, _, lhs2), .withMixedTypes(rhs0, _, rhs2)):
+                            lhs0 == rhs0 && lhs2 == rhs2
+                        default:
+                            false
+                        }
                     }
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableIgnoresClosures() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable enum ClosureEnum {
-                case withSimpleClosure(() -> Void)
-                case withParameterClosure((Int) -> String)
-                case withMultiParamClosure((Int, String) -> Bool)
-                case withEscapingClosure(@escaping () -> Void)
-                case withEscapingParameterClosure(@escaping (String) -> Int)
-                case withAutoclosure(@autoclosure () -> String)
-                case withSendableClosure(@Sendable () -> Void)
-                case withComplexClosure((Int, String) -> (Bool, Double))
-                case withMixedTypes(id: Int, callback: () -> Void, name: String)
-                case withMultipleMixed(Int, (String) -> Bool, Double, @escaping () -> Void)
-            }
-            """#,
-            expandedSource: #"""
-            enum ClosureEnum {
-                case withSimpleClosure(() -> Void)
-                case withParameterClosure((Int) -> String)
-                case withMultiParamClosure((Int, String) -> Bool)
-                case withEscapingClosure(@escaping () -> Void)
-                case withEscapingParameterClosure(@escaping (String) -> Int)
-                case withAutoclosure(@autoclosure () -> String)
-                case withSendableClosure(@Sendable () -> Void)
-                case withComplexClosure((Int, String) -> (Bool, Double))
-                case withMixedTypes(id: Int, callback: () -> Void, name: String)
-                case withMultipleMixed(Int, (String) -> Bool, Double, @escaping () -> Void)
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable enum ClosureEnum {
+                    case withSimpleClosure(() -> Void)
+                    case withParameterClosure((Int) -> String)
+                    case withMultiParamClosure((Int, String) -> Bool)
+                    case withEscapingClosure(@escaping () -> Void)
+                    case withEscapingParameterClosure(@escaping (String) -> Int)
+                    case withAutoclosure(@autoclosure () -> String)
+                    case withSendableClosure(@Sendable () -> Void)
+                    case withComplexClosure((Int, String) -> (Bool, Double))
+                    case withMixedTypes(id: Int, callback: () -> Void, name: String)
+                    case withMultipleMixed(Int, (String) -> Bool, Double, @escaping () -> Void)
+                }
+                """#,
+                expandedSource: #"""
+                enum ClosureEnum {
+                    case withSimpleClosure(() -> Void)
+                    case withParameterClosure((Int) -> String)
+                    case withMultiParamClosure((Int, String) -> Bool)
+                    case withEscapingClosure(@escaping () -> Void)
+                    case withEscapingParameterClosure(@escaping (String) -> Int)
+                    case withAutoclosure(@autoclosure () -> String)
+                    case withSendableClosure(@Sendable () -> Void)
+                    case withComplexClosure((Int, String) -> (Bool, Double))
+                    case withMixedTypes(id: Int, callback: () -> Void, name: String)
+                    case withMultipleMixed(Int, (String) -> Bool, Double, @escaping () -> Void)
+                }
 
-            extension ClosureEnum: Equatable {
-                static func ==(lhs: ClosureEnum, rhs: ClosureEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case let (.withSimpleClosure(_), .withSimpleClosure(_)):
-                        true
-                    case let (.withParameterClosure(_), .withParameterClosure(_)):
-                        true
-                    case let (.withMultiParamClosure(_), .withMultiParamClosure(_)):
-                        true
-                    case let (.withEscapingClosure(_), .withEscapingClosure(_)):
-                        true
-                    case let (.withEscapingParameterClosure(_), .withEscapingParameterClosure(_)):
-                        true
-                    case let (.withAutoclosure(_), .withAutoclosure(_)):
-                        true
-                    case let (.withSendableClosure(_), .withSendableClosure(_)):
-                        true
-                    case let (.withComplexClosure(_), .withComplexClosure(_)):
-                        true
-                    case let (.withMixedTypes(lhs0, _, lhs2), .withMixedTypes(rhs0, _, rhs2)):
-                        lhs0 == rhs0 && lhs2 == rhs2
-                    case let (.withMultipleMixed(lhs0, _, lhs2, _), .withMultipleMixed(rhs0, _, rhs2, _)):
-                        lhs0 == rhs0 && lhs2 == rhs2
-                    default:
-                        false
+                extension ClosureEnum: Equatable {
+                    static func ==(lhs: ClosureEnum, rhs: ClosureEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case let (.withSimpleClosure(_), .withSimpleClosure(_)):
+                            true
+                        case let (.withParameterClosure(_), .withParameterClosure(_)):
+                            true
+                        case let (.withMultiParamClosure(_), .withMultiParamClosure(_)):
+                            true
+                        case let (.withEscapingClosure(_), .withEscapingClosure(_)):
+                            true
+                        case let (.withEscapingParameterClosure(_), .withEscapingParameterClosure(_)):
+                            true
+                        case let (.withAutoclosure(_), .withAutoclosure(_)):
+                            true
+                        case let (.withSendableClosure(_), .withSendableClosure(_)):
+                            true
+                        case let (.withComplexClosure(_), .withComplexClosure(_)):
+                            true
+                        case let (.withMixedTypes(lhs0, _, lhs2), .withMixedTypes(rhs0, _, rhs2)):
+                            lhs0 == rhs0 && lhs2 == rhs2
+                        case let (.withMultipleMixed(lhs0, _, lhs2, _), .withMultipleMixed(rhs0, _, rhs2, _)):
+                            lhs0 == rhs0 && lhs2 == rhs2
+                        default:
+                            false
+                        }
                     }
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableIgnoresClosuresInStructs() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable struct ClosureStruct {
-                let id: Int
-                let name: String
-                let onTap: () -> Void
-                let onComplete: @escaping (Bool) -> Void
-                let transform: (String) -> Int
-                let validator: @Sendable (String) -> Bool
-            }
-            """#,
-            expandedSource: #"""
-            struct ClosureStruct {
-                let id: Int
-                let name: String
-                let onTap: () -> Void
-                let onComplete: @escaping (Bool) -> Void
-                let transform: (String) -> Int
-                let validator: @Sendable (String) -> Bool
-            }
-            
-            extension ClosureStruct: Equatable {
-                static func ==(lhs: ClosureStruct, rhs: ClosureStruct) -> Bool {
-                    lhs.id == rhs.id && lhs.name == rhs.name
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable struct ClosureStruct {
+                    let id: Int
+                    let name: String
+                    let onTap: () -> Void
+                    let onComplete: @escaping (Bool) -> Void
+                    let transform: (String) -> Int
+                    let validator: @Sendable (String) -> Bool
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                expandedSource: #"""
+                struct ClosureStruct {
+                    let id: Int
+                    let name: String
+                    let onTap: () -> Void
+                    let onComplete: @escaping (Bool) -> Void
+                    let transform: (String) -> Int
+                    let validator: @Sendable (String) -> Bool
+                }
+
+                extension ClosureStruct: Equatable {
+                    static func ==(lhs: ClosureStruct, rhs: ClosureStruct) -> Bool {
+                        lhs.id == rhs.id && lhs.name == rhs.name
+                    }
+                }
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableIgnoresClosuresInClasses() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable class ClosureClass {
-                let id: Int
-                let completion: @escaping () -> Void
-                let handler: (String) -> Bool
-                let processor: @Sendable (Data) -> String
-                var counter: Int
-            }
-            """#,
-            expandedSource: #"""
-            class ClosureClass {
-                let id: Int
-                let completion: @escaping () -> Void
-                let handler: (String) -> Bool
-                let processor: @Sendable (Data) -> String
-                var counter: Int
-            }
-
-            extension ClosureClass: Equatable {
-                static func ==(lhs: ClosureClass, rhs: ClosureClass) -> Bool {
-                    lhs.id == rhs.id && lhs.counter == rhs.counter
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable class ClosureClass {
+                    let id: Int
+                    let completion: @escaping () -> Void
+                    let handler: (String) -> Bool
+                    let processor: @Sendable (Data) -> String
+                    var counter: Int
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                expandedSource: #"""
+                class ClosureClass {
+                    let id: Int
+                    let completion: @escaping () -> Void
+                    let handler: (String) -> Bool
+                    let processor: @Sendable (Data) -> String
+                    var counter: Int
+                }
+
+                extension ClosureClass: Equatable {
+                    static func ==(lhs: ClosureClass, rhs: ClosureClass) -> Bool {
+                        lhs.id == rhs.id && lhs.counter == rhs.counter
+                    }
+                }
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableForEnumWithAllClosureEdgeCases() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoEquatable enum ClosureEdgeCasesEnum {
-                case withOptionalClosure(((String) -> Int)?)
-                case withImplicitlyUnwrappedClosure((() -> Void)!)
-                case withNestedClosure(((Int) -> ((String) -> Bool))?)
-                case withThrowingClosure((String) throws -> Int)
-                case withAsyncClosure((String) async -> Int)
-                case withAsyncThrowingClosure((String) async throws -> Int)
-                case withMultipleClosures(
-                    callback1: ((Int) -> Void)?,
-                    value: String,
-                    callback2: (() -> String)?,
-                    count: Int,
-                    callback3: @escaping (Bool) -> Void
-                )
-            }
-            """#,
-            expandedSource: #"""
-            enum ClosureEdgeCasesEnum {
-                case withOptionalClosure(((String) -> Int)?)
-                case withImplicitlyUnwrappedClosure((() -> Void)!)
-                case withNestedClosure(((Int) -> ((String) -> Bool))?)
-                case withThrowingClosure((String) throws -> Int)
-                case withAsyncClosure((String) async -> Int)
-                case withAsyncThrowingClosure((String) async throws -> Int)
-                case withMultipleClosures(
-                    callback1: ((Int) -> Void)?,
-                    value: String,
-                    callback2: (() -> String)?,
-                    count: Int,
-                    callback3: @escaping (Bool) -> Void
-                )
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoEquatable enum ClosureEdgeCasesEnum {
+                    case withOptionalClosure(((String) -> Int)?)
+                    case withImplicitlyUnwrappedClosure((() -> Void)!)
+                    case withNestedClosure(((Int) -> ((String) -> Bool))?)
+                    case withThrowingClosure((String) throws -> Int)
+                    case withAsyncClosure((String) async -> Int)
+                    case withAsyncThrowingClosure((String) async throws -> Int)
+                    case withMultipleClosures(
+                        callback1: ((Int) -> Void)?,
+                        value: String,
+                        callback2: (() -> String)?,
+                        count: Int,
+                        callback3: @escaping (Bool) -> Void
+                    )
+                }
+                """#,
+                expandedSource: #"""
+                enum ClosureEdgeCasesEnum {
+                    case withOptionalClosure(((String) -> Int)?)
+                    case withImplicitlyUnwrappedClosure((() -> Void)!)
+                    case withNestedClosure(((Int) -> ((String) -> Bool))?)
+                    case withThrowingClosure((String) throws -> Int)
+                    case withAsyncClosure((String) async -> Int)
+                    case withAsyncThrowingClosure((String) async throws -> Int)
+                    case withMultipleClosures(
+                        callback1: ((Int) -> Void)?,
+                        value: String,
+                        callback2: (() -> String)?,
+                        count: Int,
+                        callback3: @escaping (Bool) -> Void
+                    )
+                }
 
-            extension ClosureEdgeCasesEnum: Equatable {
-                static func ==(lhs: ClosureEdgeCasesEnum, rhs: ClosureEdgeCasesEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case let (.withOptionalClosure(_), .withOptionalClosure(_)):
-                        true
-                    case let (.withImplicitlyUnwrappedClosure(_), .withImplicitlyUnwrappedClosure(_)):
-                        true
-                    case let (.withNestedClosure(_), .withNestedClosure(_)):
-                        true
-                    case let (.withThrowingClosure(_), .withThrowingClosure(_)):
-                        true
-                    case let (.withAsyncClosure(_), .withAsyncClosure(_)):
-                        true
-                    case let (.withAsyncThrowingClosure(_), .withAsyncThrowingClosure(_)):
-                        true
-                    case let (.withMultipleClosures(_, lhs1, _, lhs3, _), .withMultipleClosures(_, rhs1, _, rhs3, _)):
-                        lhs1 == rhs1 && lhs3 == rhs3
-                    default:
-                        false
+                extension ClosureEdgeCasesEnum: Equatable {
+                    static func ==(lhs: ClosureEdgeCasesEnum, rhs: ClosureEdgeCasesEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case let (.withOptionalClosure(_), .withOptionalClosure(_)):
+                            true
+                        case let (.withImplicitlyUnwrappedClosure(_), .withImplicitlyUnwrappedClosure(_)):
+                            true
+                        case let (.withNestedClosure(_), .withNestedClosure(_)):
+                            true
+                        case let (.withThrowingClosure(_), .withThrowingClosure(_)):
+                            true
+                        case let (.withAsyncClosure(_), .withAsyncClosure(_)):
+                            true
+                        case let (.withAsyncThrowingClosure(_), .withAsyncThrowingClosure(_)):
+                            true
+                        case let (.withMultipleClosures(_, lhs1, _, lhs3, _), .withMultipleClosures(_, rhs1, _, rhs3, _)):
+                            lhs1 == rhs1 && lhs3 == rhs3
+                        default:
+                            false
+                        }
                     }
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoEquatableForEnumWithCommandWithTypeAlias() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            public typealias CommandWith<T> = (T) -> Void
-            
-            @AutoEquatable enum RouteEnum {
-                case detailsView(
-                    postID: Post.ID,
-                    isInitiallyInteractive: Bool,
-                    triggerAutoScrollAction: CommandWith<AutoScrollTrigger>
-                )
-                case listView(
-                    categoryID: Category.ID,
-                    onSelectionChanged: CommandWith<Item.ID>,
-                    refreshAction: () -> Void
-                )
-                case simpleView(name: String)
-            }
-            """#,
-            expandedSource: #"""
-            public typealias CommandWith<T> = (T) -> Void
-            
-            enum RouteEnum {
-                case detailsView(
-                    postID: Post.ID,
-                    isInitiallyInteractive: Bool,
-                    triggerAutoScrollAction: CommandWith<AutoScrollTrigger>
-                )
-                case listView(
-                    categoryID: Category.ID,
-                    onSelectionChanged: CommandWith<Item.ID>,
-                    refreshAction: () -> Void
-                )
-                case simpleView(name: String)
-            }
+            assertMacroExpansion(
+                #"""
+                public typealias CommandWith<T> = (T) -> Void
 
-            extension RouteEnum: Equatable {
-                static func ==(lhs: RouteEnum, rhs: RouteEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case let (.detailsView(lhs0, lhs1, _), .detailsView(rhs0, rhs1, _)):
-                        lhs0 == rhs0 && lhs1 == rhs1
-                    case let (.listView(lhs0, _, _), .listView(rhs0, _, _)):
-                        lhs0 == rhs0
-                    case let (.simpleView(lhs0), .simpleView(rhs0)):
-                        lhs0 == rhs0
-                    default:
-                        false
+                @AutoEquatable enum RouteEnum {
+                    case detailsView(
+                        postID: Post.ID,
+                        isInitiallyInteractive: Bool,
+                        triggerAutoScrollAction: CommandWith<AutoScrollTrigger>
+                    )
+                    case listView(
+                        categoryID: Category.ID,
+                        onSelectionChanged: CommandWith<Item.ID>,
+                        refreshAction: () -> Void
+                    )
+                    case simpleView(name: String)
+                }
+                """#,
+                expandedSource: #"""
+                public typealias CommandWith<T> = (T) -> Void
+
+                enum RouteEnum {
+                    case detailsView(
+                        postID: Post.ID,
+                        isInitiallyInteractive: Bool,
+                        triggerAutoScrollAction: CommandWith<AutoScrollTrigger>
+                    )
+                    case listView(
+                        categoryID: Category.ID,
+                        onSelectionChanged: CommandWith<Item.ID>,
+                        refreshAction: () -> Void
+                    )
+                    case simpleView(name: String)
+                }
+
+                extension RouteEnum: Equatable {
+                    static func ==(lhs: RouteEnum, rhs: RouteEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case let (.detailsView(lhs0, lhs1, _), .detailsView(rhs0, rhs1, _)):
+                            lhs0 == rhs0 && lhs1 == rhs1
+                        case let (.listView(lhs0, _, _), .listView(rhs0, _, _)):
+                            lhs0 == rhs0
+                        case let (.simpleView(lhs0), .simpleView(rhs0)):
+                            lhs0 == rhs0
+                        default:
+                            false
+                        }
                     }
                 }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     // MARK: - AutoHashable Tests
-    
+
     func testAutoHashableForStruct() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoHashable struct TestStruct {
-                let id: Int
-                let name: String
-                let value: Double
-                let active: Bool
-            }
-            """#,
-            expandedSource: #"""
-            struct TestStruct {
-                let id: Int
-                let name: String
-                let value: Double
-                let active: Bool
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoHashable struct TestStruct {
+                    let id: Int
+                    let name: String
+                    let value: Double
+                    let active: Bool
+                }
+                """#,
+                expandedSource: #"""
+                struct TestStruct {
+                    let id: Int
+                    let name: String
+                    let value: Double
+                    let active: Bool
+                }
 
-            extension TestStruct: Hashable {
-                static func ==(lhs: TestStruct, rhs: TestStruct) -> Bool {
-                    lhs.id == rhs.id && lhs.name == rhs.name && lhs.value == rhs.value && lhs.active == rhs.active
+                extension TestStruct: Hashable {
+                    static func ==(lhs: TestStruct, rhs: TestStruct) -> Bool {
+                        lhs.id == rhs.id && lhs.name == rhs.name && lhs.value == rhs.value && lhs.active == rhs.active
+                    }
+                    func hash(into hasher: inout Hasher) {
+                        hasher.combine(id)
+                        hasher.combine(name)
+                        hasher.combine(value)
+                        hasher.combine(active)
+                    }
                 }
-                func hash(into hasher: inout Hasher) {
-                    hasher.combine(id)
-                    hasher.combine(name)
-                    hasher.combine(value)
-                    hasher.combine(active)
-                }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoHashableForClass() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoHashable class TestClass {
-                let id: Int
-                let name: String
-                var counter: Int
-            }
-            """#,
-            expandedSource: #"""
-            class TestClass {
-                let id: Int
-                let name: String
-                var counter: Int
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoHashable class TestClass {
+                    let id: Int
+                    let name: String
+                    var counter: Int
+                }
+                """#,
+                expandedSource: #"""
+                class TestClass {
+                    let id: Int
+                    let name: String
+                    var counter: Int
+                }
 
-            extension TestClass: Hashable {
-                static func ==(lhs: TestClass, rhs: TestClass) -> Bool {
-                    lhs.id == rhs.id && lhs.name == rhs.name && lhs.counter == rhs.counter
+                extension TestClass: Hashable {
+                    static func ==(lhs: TestClass, rhs: TestClass) -> Bool {
+                        lhs.id == rhs.id && lhs.name == rhs.name && lhs.counter == rhs.counter
+                    }
+                    func hash(into hasher: inout Hasher) {
+                        hasher.combine(id)
+                        hasher.combine(name)
+                        hasher.combine(counter)
+                    }
                 }
-                func hash(into hasher: inout Hasher) {
-                    hasher.combine(id)
-                    hasher.combine(name)
-                    hasher.combine(counter)
-                }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoHashableForEnum() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoHashable enum TestEnum {
-                case simple
-                case withInt(Int)
-                case withMultiple(Int, String)
-                case withMixed(id: Int, name: String, active: Bool)
-            }
-            """#,
-            expandedSource: #"""
-            enum TestEnum {
-                case simple
-                case withInt(Int)
-                case withMultiple(Int, String)
-                case withMixed(id: Int, name: String, active: Bool)
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoHashable enum TestEnum {
+                    case simple
+                    case withInt(Int)
+                    case withMultiple(Int, String)
+                    case withMixed(id: Int, name: String, active: Bool)
+                }
+                """#,
+                expandedSource: #"""
+                enum TestEnum {
+                    case simple
+                    case withInt(Int)
+                    case withMultiple(Int, String)
+                    case withMixed(id: Int, name: String, active: Bool)
+                }
 
-            extension TestEnum: Hashable {
-                static func ==(lhs: TestEnum, rhs: TestEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case (.simple, .simple):
-                        true
-                    case let (.withInt(lhs0), .withInt(rhs0)):
-                        lhs0 == rhs0
-                    case let (.withMultiple(lhs0, lhs1), .withMultiple(rhs0, rhs1)):
-                        lhs0 == rhs0 && lhs1 == rhs1
-                    case let (.withMixed(lhs0, lhs1, lhs2), .withMixed(rhs0, rhs1, rhs2)):
-                        lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2
-                    default:
-                        false
+                extension TestEnum: Hashable {
+                    static func ==(lhs: TestEnum, rhs: TestEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case (.simple, .simple):
+                            true
+                        case let (.withInt(lhs0), .withInt(rhs0)):
+                            lhs0 == rhs0
+                        case let (.withMultiple(lhs0, lhs1), .withMultiple(rhs0, rhs1)):
+                            lhs0 == rhs0 && lhs1 == rhs1
+                        case let (.withMixed(lhs0, lhs1, lhs2), .withMixed(rhs0, rhs1, rhs2)):
+                            lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2
+                        default:
+                            false
+                        }
+                    }
+                    func hash(into hasher: inout Hasher) {
+                        switch self {
+                        case .simple:
+                            hasher.combine("simple")
+                        case let .withInt(value0):
+                            hasher.combine("withInt")
+                            hasher.combine(value0)
+                        case let .withMultiple(value0, value1):
+                            hasher.combine("withMultiple")
+                            hasher.combine(value0)
+                            hasher.combine(value1)
+                        case let .withMixed(value0, value1, value2):
+                            hasher.combine("withMixed")
+                            hasher.combine(value0)
+                            hasher.combine(value1)
+                            hasher.combine(value2)
+                        }
                     }
                 }
-                func hash(into hasher: inout Hasher) {
-                    switch self {
-                    case .simple:
-                        hasher.combine("simple")
-                    case let .withInt(value0):
-                        hasher.combine("withInt")
-                        hasher.combine(value0)
-                    case let .withMultiple(value0, value1):
-                        hasher.combine("withMultiple")
-                        hasher.combine(value0)
-                        hasher.combine(value1)
-                    case let .withMixed(value0, value1, value2):
-                        hasher.combine("withMixed")
-                        hasher.combine(value0)
-                        hasher.combine(value1)
-                        hasher.combine(value2)
-                    }
-                }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoHashableExcludesClosures() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoHashable struct ClosureStruct {
-                let id: Int
-                let callback: () -> Void
-                let name: String
-                let handler: @escaping (Int) -> String
-            }
-            """#,
-            expandedSource: #"""
-            struct ClosureStruct {
-                let id: Int
-                let callback: () -> Void
-                let name: String
-                let handler: @escaping (Int) -> String
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoHashable struct ClosureStruct {
+                    let id: Int
+                    let callback: () -> Void
+                    let name: String
+                    let handler: @escaping (Int) -> String
+                }
+                """#,
+                expandedSource: #"""
+                struct ClosureStruct {
+                    let id: Int
+                    let callback: () -> Void
+                    let name: String
+                    let handler: @escaping (Int) -> String
+                }
 
-            extension ClosureStruct: Hashable {
-                static func ==(lhs: ClosureStruct, rhs: ClosureStruct) -> Bool {
-                    lhs.id == rhs.id && lhs.name == rhs.name
+                extension ClosureStruct: Hashable {
+                    static func ==(lhs: ClosureStruct, rhs: ClosureStruct) -> Bool {
+                        lhs.id == rhs.id && lhs.name == rhs.name
+                    }
+                    func hash(into hasher: inout Hasher) {
+                        hasher.combine(id)
+                        hasher.combine(name)
+                    }
                 }
-                func hash(into hasher: inout Hasher) {
-                    hasher.combine(id)
-                    hasher.combine(name)
-                }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoHashableExcludesVoidAndNever() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoHashable struct EdgeCaseStruct {
-                let id: Int
-                let voidValue: Void
-                let neverValue: Never
-                let name: String
-            }
-            """#,
-            expandedSource: #"""
-            struct EdgeCaseStruct {
-                let id: Int
-                let voidValue: Void
-                let neverValue: Never
-                let name: String
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoHashable struct EdgeCaseStruct {
+                    let id: Int
+                    let voidValue: Void
+                    let neverValue: Never
+                    let name: String
+                }
+                """#,
+                expandedSource: #"""
+                struct EdgeCaseStruct {
+                    let id: Int
+                    let voidValue: Void
+                    let neverValue: Never
+                    let name: String
+                }
 
-            extension EdgeCaseStruct: Hashable {
-                static func ==(lhs: EdgeCaseStruct, rhs: EdgeCaseStruct) -> Bool {
-                    lhs.id == rhs.id && lhs.name == rhs.name
+                extension EdgeCaseStruct: Hashable {
+                    static func ==(lhs: EdgeCaseStruct, rhs: EdgeCaseStruct) -> Bool {
+                        lhs.id == rhs.id && lhs.name == rhs.name
+                    }
+                    func hash(into hasher: inout Hasher) {
+                        hasher.combine(id)
+                        hasher.combine(name)
+                    }
                 }
-                func hash(into hasher: inout Hasher) {
-                    hasher.combine(id)
-                    hasher.combine(name)
-                }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoHashableWithCollectionsAndOptionals() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoHashable struct CollectionStruct {
-                let ids: [Int]
-                let names: [String]
-                let optionalId: Int?
-                let optionalName: String?
-                let stringSet: Set<String>
-                let mapping: Dictionary<String, Int>
-            }
-            """#,
-            expandedSource: #"""
-            struct CollectionStruct {
-                let ids: [Int]
-                let names: [String]
-                let optionalId: Int?
-                let optionalName: String?
-                let stringSet: Set<String>
-                let mapping: Dictionary<String, Int>
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoHashable struct CollectionStruct {
+                    let ids: [Int]
+                    let names: [String]
+                    let optionalId: Int?
+                    let optionalName: String?
+                    let stringSet: Set<String>
+                    let mapping: Dictionary<String, Int>
+                }
+                """#,
+                expandedSource: #"""
+                struct CollectionStruct {
+                    let ids: [Int]
+                    let names: [String]
+                    let optionalId: Int?
+                    let optionalName: String?
+                    let stringSet: Set<String>
+                    let mapping: Dictionary<String, Int>
+                }
 
-            extension CollectionStruct: Hashable {
-                static func ==(lhs: CollectionStruct, rhs: CollectionStruct) -> Bool {
-                    lhs.ids == rhs.ids && lhs.names == rhs.names && lhs.optionalId == rhs.optionalId && lhs.optionalName == rhs.optionalName && lhs.stringSet == rhs.stringSet && lhs.mapping == rhs.mapping
+                extension CollectionStruct: Hashable {
+                    static func ==(lhs: CollectionStruct, rhs: CollectionStruct) -> Bool {
+                        lhs.ids == rhs.ids && lhs.names == rhs.names && lhs.optionalId == rhs.optionalId && lhs.optionalName == rhs.optionalName && lhs.stringSet == rhs.stringSet && lhs.mapping == rhs.mapping
+                    }
+                    func hash(into hasher: inout Hasher) {
+                        hasher.combine(ids)
+                        hasher.combine(names)
+                        hasher.combine(optionalId)
+                        hasher.combine(optionalName)
+                        hasher.combine(stringSet)
+                        hasher.combine(mapping)
+                    }
                 }
-                func hash(into hasher: inout Hasher) {
-                    hasher.combine(ids)
-                    hasher.combine(names)
-                    hasher.combine(optionalId)
-                    hasher.combine(optionalName)
-                    hasher.combine(stringSet)
-                    hasher.combine(mapping)
-                }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoHashableEnumWithClosures() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoHashable enum ClosureEnum {
-                case withClosure(() -> Void)
-                case withValues(Int, String)
-                case withMixed(id: Int, callback: @escaping () -> Void, name: String)
-            }
-            """#,
-            expandedSource: #"""
-            enum ClosureEnum {
-                case withClosure(() -> Void)
-                case withValues(Int, String)
-                case withMixed(id: Int, callback: @escaping () -> Void, name: String)
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoHashable enum ClosureEnum {
+                    case withClosure(() -> Void)
+                    case withValues(Int, String)
+                    case withMixed(id: Int, callback: @escaping () -> Void, name: String)
+                }
+                """#,
+                expandedSource: #"""
+                enum ClosureEnum {
+                    case withClosure(() -> Void)
+                    case withValues(Int, String)
+                    case withMixed(id: Int, callback: @escaping () -> Void, name: String)
+                }
 
-            extension ClosureEnum: Hashable {
-                static func ==(lhs: ClosureEnum, rhs: ClosureEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case let (.withClosure(_), .withClosure(_)):
-                        true
-                    case let (.withValues(lhs0, lhs1), .withValues(rhs0, rhs1)):
-                        lhs0 == rhs0 && lhs1 == rhs1
-                    case let (.withMixed(lhs0, _, lhs2), .withMixed(rhs0, _, rhs2)):
-                        lhs0 == rhs0 && lhs2 == rhs2
-                    default:
-                        false
+                extension ClosureEnum: Hashable {
+                    static func ==(lhs: ClosureEnum, rhs: ClosureEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case let (.withClosure(_), .withClosure(_)):
+                            true
+                        case let (.withValues(lhs0, lhs1), .withValues(rhs0, rhs1)):
+                            lhs0 == rhs0 && lhs1 == rhs1
+                        case let (.withMixed(lhs0, _, lhs2), .withMixed(rhs0, _, rhs2)):
+                            lhs0 == rhs0 && lhs2 == rhs2
+                        default:
+                            false
+                        }
+                    }
+                    func hash(into hasher: inout Hasher) {
+                        switch self {
+                        case .withClosure:
+                            hasher.combine("withClosure")
+                        case let .withValues(value0, value1):
+                            hasher.combine("withValues")
+                            hasher.combine(value0)
+                            hasher.combine(value1)
+                        case let .withMixed(value0, _, value2):
+                            hasher.combine("withMixed")
+                            hasher.combine(value0)
+                            hasher.combine(value2)
+                        }
                     }
                 }
-                func hash(into hasher: inout Hasher) {
-                    switch self {
-                    case .withClosure:
-                        hasher.combine("withClosure")
-                    case let .withValues(value0, value1):
-                        hasher.combine("withValues")
-                        hasher.combine(value0)
-                        hasher.combine(value1)
-                    case let .withMixed(value0, _, value2):
-                        hasher.combine("withMixed")
-                        hasher.combine(value0)
-                        hasher.combine(value2)
-                    }
-                }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoHashableWorksWithAnyHashableType() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoHashable struct UnknownTypesStruct {
-                let customType: CustomHashableType
-                let anotherType: SomeOtherHashableType
-                let nestedArray: [[[CustomHashableType]]]
-                let tuple: (CustomHashableType, AnotherHashableType)
-                let optionalCustom: CustomHashableType?
-            }
-            """#,
-            expandedSource: #"""
-            struct UnknownTypesStruct {
-                let customType: CustomHashableType
-                let anotherType: SomeOtherHashableType
-                let nestedArray: [[[CustomHashableType]]]
-                let tuple: (CustomHashableType, AnotherHashableType)
-                let optionalCustom: CustomHashableType?
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoHashable struct UnknownTypesStruct {
+                    let customType: CustomHashableType
+                    let anotherType: SomeOtherHashableType
+                    let nestedArray: [[[CustomHashableType]]]
+                    let tuple: (CustomHashableType, AnotherHashableType)
+                    let optionalCustom: CustomHashableType?
+                }
+                """#,
+                expandedSource: #"""
+                struct UnknownTypesStruct {
+                    let customType: CustomHashableType
+                    let anotherType: SomeOtherHashableType
+                    let nestedArray: [[[CustomHashableType]]]
+                    let tuple: (CustomHashableType, AnotherHashableType)
+                    let optionalCustom: CustomHashableType?
+                }
 
-            extension UnknownTypesStruct: Hashable {
-                static func ==(lhs: UnknownTypesStruct, rhs: UnknownTypesStruct) -> Bool {
-                    lhs.customType == rhs.customType && lhs.anotherType == rhs.anotherType && lhs.nestedArray == rhs.nestedArray && lhs.tuple == rhs.tuple && lhs.optionalCustom == rhs.optionalCustom
+                extension UnknownTypesStruct: Hashable {
+                    static func ==(lhs: UnknownTypesStruct, rhs: UnknownTypesStruct) -> Bool {
+                        lhs.customType == rhs.customType && lhs.anotherType == rhs.anotherType && lhs.nestedArray == rhs.nestedArray && lhs.tuple == rhs.tuple && lhs.optionalCustom == rhs.optionalCustom
+                    }
+                    func hash(into hasher: inout Hasher) {
+                        hasher.combine(customType)
+                        hasher.combine(anotherType)
+                        hasher.combine(nestedArray)
+                        hasher.combine(tuple)
+                        hasher.combine(optionalCustom)
+                    }
                 }
-                func hash(into hasher: inout Hasher) {
-                    hasher.combine(customType)
-                    hasher.combine(anotherType)
-                    hasher.combine(nestedArray)
-                    hasher.combine(tuple)
-                    hasher.combine(optionalCustom)
-                }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoHashableForEnumWithAllClosureEdgeCases() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            @AutoHashable enum ClosureEdgeCasesEnum {
-                case withOptionalClosure(((String) -> Int)?)
-                case withImplicitlyUnwrappedClosure((() -> Void)!)
-                case withNestedClosure(((Int) -> ((String) -> Bool))?)
-                case withThrowingClosure((String) throws -> Int)
-                case withAsyncClosure((String) async -> Int)
-                case withAsyncThrowingClosure((String) async throws -> Int)
-                case withMultipleClosures(
-                    callback1: ((Int) -> Void)?,
-                    value: String,
-                    callback2: (() -> String)?,
-                    count: Int,
-                    callback3: @escaping (Bool) -> Void
-                )
-            }
-            """#,
-            expandedSource: #"""
-            enum ClosureEdgeCasesEnum {
-                case withOptionalClosure(((String) -> Int)?)
-                case withImplicitlyUnwrappedClosure((() -> Void)!)
-                case withNestedClosure(((Int) -> ((String) -> Bool))?)
-                case withThrowingClosure((String) throws -> Int)
-                case withAsyncClosure((String) async -> Int)
-                case withAsyncThrowingClosure((String) async throws -> Int)
-                case withMultipleClosures(
-                    callback1: ((Int) -> Void)?,
-                    value: String,
-                    callback2: (() -> String)?,
-                    count: Int,
-                    callback3: @escaping (Bool) -> Void
-                )
-            }
+            assertMacroExpansion(
+                #"""
+                @AutoHashable enum ClosureEdgeCasesEnum {
+                    case withOptionalClosure(((String) -> Int)?)
+                    case withImplicitlyUnwrappedClosure((() -> Void)!)
+                    case withNestedClosure(((Int) -> ((String) -> Bool))?)
+                    case withThrowingClosure((String) throws -> Int)
+                    case withAsyncClosure((String) async -> Int)
+                    case withAsyncThrowingClosure((String) async throws -> Int)
+                    case withMultipleClosures(
+                        callback1: ((Int) -> Void)?,
+                        value: String,
+                        callback2: (() -> String)?,
+                        count: Int,
+                        callback3: @escaping (Bool) -> Void
+                    )
+                }
+                """#,
+                expandedSource: #"""
+                enum ClosureEdgeCasesEnum {
+                    case withOptionalClosure(((String) -> Int)?)
+                    case withImplicitlyUnwrappedClosure((() -> Void)!)
+                    case withNestedClosure(((Int) -> ((String) -> Bool))?)
+                    case withThrowingClosure((String) throws -> Int)
+                    case withAsyncClosure((String) async -> Int)
+                    case withAsyncThrowingClosure((String) async throws -> Int)
+                    case withMultipleClosures(
+                        callback1: ((Int) -> Void)?,
+                        value: String,
+                        callback2: (() -> String)?,
+                        count: Int,
+                        callback3: @escaping (Bool) -> Void
+                    )
+                }
 
-            extension ClosureEdgeCasesEnum: Hashable {
-                static func ==(lhs: ClosureEdgeCasesEnum, rhs: ClosureEdgeCasesEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case let (.withOptionalClosure(_), .withOptionalClosure(_)):
-                        true
-                    case let (.withImplicitlyUnwrappedClosure(_), .withImplicitlyUnwrappedClosure(_)):
-                        true
-                    case let (.withNestedClosure(_), .withNestedClosure(_)):
-                        true
-                    case let (.withThrowingClosure(_), .withThrowingClosure(_)):
-                        true
-                    case let (.withAsyncClosure(_), .withAsyncClosure(_)):
-                        true
-                    case let (.withAsyncThrowingClosure(_), .withAsyncThrowingClosure(_)):
-                        true
-                    case let (.withMultipleClosures(_, lhs1, _, lhs3, _), .withMultipleClosures(_, rhs1, _, rhs3, _)):
-                        lhs1 == rhs1 && lhs3 == rhs3
-                    default:
-                        false
+                extension ClosureEdgeCasesEnum: Hashable {
+                    static func ==(lhs: ClosureEdgeCasesEnum, rhs: ClosureEdgeCasesEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case let (.withOptionalClosure(_), .withOptionalClosure(_)):
+                            true
+                        case let (.withImplicitlyUnwrappedClosure(_), .withImplicitlyUnwrappedClosure(_)):
+                            true
+                        case let (.withNestedClosure(_), .withNestedClosure(_)):
+                            true
+                        case let (.withThrowingClosure(_), .withThrowingClosure(_)):
+                            true
+                        case let (.withAsyncClosure(_), .withAsyncClosure(_)):
+                            true
+                        case let (.withAsyncThrowingClosure(_), .withAsyncThrowingClosure(_)):
+                            true
+                        case let (.withMultipleClosures(_, lhs1, _, lhs3, _), .withMultipleClosures(_, rhs1, _, rhs3, _)):
+                            lhs1 == rhs1 && lhs3 == rhs3
+                        default:
+                            false
+                        }
+                    }
+                    func hash(into hasher: inout Hasher) {
+                        switch self {
+                        case .withOptionalClosure:
+                            hasher.combine("withOptionalClosure")
+                        case .withImplicitlyUnwrappedClosure:
+                            hasher.combine("withImplicitlyUnwrappedClosure")
+                        case .withNestedClosure:
+                            hasher.combine("withNestedClosure")
+                        case .withThrowingClosure:
+                            hasher.combine("withThrowingClosure")
+                        case .withAsyncClosure:
+                            hasher.combine("withAsyncClosure")
+                        case .withAsyncThrowingClosure:
+                            hasher.combine("withAsyncThrowingClosure")
+                        case let .withMultipleClosures(_, value1, _, value3, _):
+                            hasher.combine("withMultipleClosures")
+                            hasher.combine(value1)
+                            hasher.combine(value3)
+                        }
                     }
                 }
-                func hash(into hasher: inout Hasher) {
-                    switch self {
-                    case .withOptionalClosure:
-                        hasher.combine("withOptionalClosure")
-                    case .withImplicitlyUnwrappedClosure:
-                        hasher.combine("withImplicitlyUnwrappedClosure")
-                    case .withNestedClosure:
-                        hasher.combine("withNestedClosure")
-                    case .withThrowingClosure:
-                        hasher.combine("withThrowingClosure")
-                    case .withAsyncClosure:
-                        hasher.combine("withAsyncClosure")
-                    case .withAsyncThrowingClosure:
-                        hasher.combine("withAsyncThrowingClosure")
-                    case let .withMultipleClosures(_, value1, _, value3, _):
-                        hasher.combine("withMultipleClosures")
-                        hasher.combine(value1)
-                        hasher.combine(value3)
-                    }
-                }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
-    
+
     func testAutoHashableForEnumWithCommandWithTypeAlias() throws {
         #if canImport(UDFMacrosMacros)
-        assertMacroExpansion(
-            #"""
-            public typealias CommandWith<T> = (T) -> Void
-            
-            @AutoHashable enum RouteEnum {
-                case detailsView(
-                    postID: Post.ID,
-                    isInitiallyInteractive: Bool,
-                    triggerAutoScrollAction: CommandWith<AutoScrollTrigger>
-                )
-                case listView(
-                    categoryID: Category.ID,
-                    onSelectionChanged: CommandWith<Item.ID>,
-                    refreshAction: () -> Void
-                )
-                case simpleView(name: String)
-            }
-            """#,
-            expandedSource: #"""
-            public typealias CommandWith<T> = (T) -> Void
-            
-            enum RouteEnum {
-                case detailsView(
-                    postID: Post.ID,
-                    isInitiallyInteractive: Bool,
-                    triggerAutoScrollAction: CommandWith<AutoScrollTrigger>
-                )
-                case listView(
-                    categoryID: Category.ID,
-                    onSelectionChanged: CommandWith<Item.ID>,
-                    refreshAction: () -> Void
-                )
-                case simpleView(name: String)
-            }
+            assertMacroExpansion(
+                #"""
+                public typealias CommandWith<T> = (T) -> Void
 
-            extension RouteEnum: Hashable {
-                static func ==(lhs: RouteEnum, rhs: RouteEnum) -> Bool {
-                    switch (lhs, rhs) {
-                    case let (.detailsView(lhs0, lhs1, _), .detailsView(rhs0, rhs1, _)):
-                        lhs0 == rhs0 && lhs1 == rhs1
-                    case let (.listView(lhs0, _, _), .listView(rhs0, _, _)):
-                        lhs0 == rhs0
-                    case let (.simpleView(lhs0), .simpleView(rhs0)):
-                        lhs0 == rhs0
-                    default:
-                        false
+                @AutoHashable enum RouteEnum {
+                    case detailsView(
+                        postID: Post.ID,
+                        isInitiallyInteractive: Bool,
+                        triggerAutoScrollAction: CommandWith<AutoScrollTrigger>
+                    )
+                    case listView(
+                        categoryID: Category.ID,
+                        onSelectionChanged: CommandWith<Item.ID>,
+                        refreshAction: () -> Void
+                    )
+                    case simpleView(name: String)
+                }
+                """#,
+                expandedSource: #"""
+                public typealias CommandWith<T> = (T) -> Void
+
+                enum RouteEnum {
+                    case detailsView(
+                        postID: Post.ID,
+                        isInitiallyInteractive: Bool,
+                        triggerAutoScrollAction: CommandWith<AutoScrollTrigger>
+                    )
+                    case listView(
+                        categoryID: Category.ID,
+                        onSelectionChanged: CommandWith<Item.ID>,
+                        refreshAction: () -> Void
+                    )
+                    case simpleView(name: String)
+                }
+
+                extension RouteEnum: Hashable {
+                    static func ==(lhs: RouteEnum, rhs: RouteEnum) -> Bool {
+                        switch (lhs, rhs) {
+                        case let (.detailsView(lhs0, lhs1, _), .detailsView(rhs0, rhs1, _)):
+                            lhs0 == rhs0 && lhs1 == rhs1
+                        case let (.listView(lhs0, _, _), .listView(rhs0, _, _)):
+                            lhs0 == rhs0
+                        case let (.simpleView(lhs0), .simpleView(rhs0)):
+                            lhs0 == rhs0
+                        default:
+                            false
+                        }
+                    }
+                    func hash(into hasher: inout Hasher) {
+                        switch self {
+                        case let .detailsView(value0, value1, _):
+                            hasher.combine("detailsView")
+                            hasher.combine(value0)
+                            hasher.combine(value1)
+                        case let .listView(value0, _, _):
+                            hasher.combine("listView")
+                            hasher.combine(value0)
+                        case let .simpleView(value0):
+                            hasher.combine("simpleView")
+                            hasher.combine(value0)
+                        }
                     }
                 }
-                func hash(into hasher: inout Hasher) {
-                    switch self {
-                    case let .detailsView(value0, value1, _):
-                        hasher.combine("detailsView")
-                        hasher.combine(value0)
-                        hasher.combine(value1)
-                    case let .listView(value0, _, _):
-                        hasher.combine("listView")
-                        hasher.combine(value0)
-                    case let .simpleView(value0):
-                        hasher.combine("simpleView")
-                        hasher.combine(value0)
-                    }
-                }
-            }
-            """#,
-            macros: testMacros
-        )
+                """#,
+                macros: testMacros
+            )
         #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testStorageBasicExpansion() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(Movie.self)
+                struct AllMovies: Reducible {
+                }
+                """,
+                expandedSource: """
+                struct AllMovies: Reducible {
+
+                    var byId: [Movie.ID: Movie] = [:]
+
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadItems<Movie>:
+                            byId.insert(items: action.items)
+
+                        case let action as Actions.DidLoadItem<Movie>:
+                            byId.insert(item: action.item)
+
+                        case let action as Actions.DidUpdateItem<Movie>:
+                            byId[action.item.id] = action.item
+
+                        case let action as Actions.DeleteItem<Movie>:
+                            byId.removeValue(forKey: action.item.id)
+
+                        default:
+                            break
+                        }
+                    }
+
+                    func movieBy(id: Movie.ID) -> Movie {
+                        byId[id] ?? .empty
+                    }
+                }
+                """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    /// Acronym-led type names ("FAQItem") should lower only the leading
+    /// uppercase run, not just the first letter.
+    func testStorageAccessorNamingForAcronymLeadingType() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(FAQItem.self)
+                struct AllFAQItems: Reducible {
+                }
+                """,
+                expandedSource: """
+                struct AllFAQItems: Reducible {
+
+                    var byId: [FAQItem.ID: FAQItem] = [:]
+
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadItems<FAQItem>:
+                            byId.insert(items: action.items)
+
+                        case let action as Actions.DidLoadItem<FAQItem>:
+                            byId.insert(item: action.item)
+
+                        case let action as Actions.DidUpdateItem<FAQItem>:
+                            byId[action.item.id] = action.item
+
+                        case let action as Actions.DeleteItem<FAQItem>:
+                            byId.removeValue(forKey: action.item.id)
+
+                        default:
+                            break
+                        }
+                    }
+
+                    func faqItemBy(id: FAQItem.ID) -> FAQItem {
+                        byId[id] ?? .empty
+                    }
+                }
+                """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    /// The escape hatch: a hand-written `reduce` (e.g. for a bespoke action
+    /// like `DidToggleFavorite`) is left untouched — `byId` and the accessor
+    /// are still generated.
+    func testStorageSkipsExistingReduce() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(Movie.self)
+                struct AllMovies: Reducible {
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidToggleFavorite<Movie>:
+                            byId[action.id]?.isFavorite.toggle()
+                        default:
+                            break
+                        }
+                    }
+                }
+                """,
+                expandedSource: """
+                struct AllMovies: Reducible {
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidToggleFavorite<Movie>:
+                            byId[action.id]?.isFavorite.toggle()
+                        default:
+                            break
+                        }
+                    }
+
+                    var byId: [Movie.ID: Movie] = [:]
+
+                    func movieBy(id: Movie.ID) -> Movie {
+                        byId[id] ?? .empty
+                    }
+                }
+                """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    /// A hand-written accessor with the same name is left untouched too.
+    func testStorageSkipsExistingAccessor() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(Movie.self)
+                struct AllMovies: Reducible {
+                    func movieBy(id: Movie.ID) -> Movie {
+                        byId[id] ?? .empty
+                    }
+                }
+                """,
+                expandedSource: """
+                struct AllMovies: Reducible {
+                    func movieBy(id: Movie.ID) -> Movie {
+                        byId[id] ?? .empty
+                    }
+
+                    var byId: [Movie.ID: Movie] = [:]
+
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadItems<Movie>:
+                            byId.insert(items: action.items)
+
+                        case let action as Actions.DidLoadItem<Movie>:
+                            byId.insert(item: action.item)
+
+                        case let action as Actions.DidUpdateItem<Movie>:
+                            byId[action.item.id] = action.item
+
+                        case let action as Actions.DeleteItem<Movie>:
+                            byId.removeValue(forKey: action.item.id)
+
+                        default:
+                            break
+                        }
+                    }
+                }
+                """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testStorageRequiresStruct() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(Movie.self)
+                class AllMovies: Reducible {
+                }
+                """,
+                expandedSource: """
+                class AllMovies: Reducible {
+                }
+                """,
+                diagnostics: [
+                    DiagnosticSpec(message: "@Storage can only be applied to a 'struct' declaration", line: 1, column: 1),
+                ],
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testStorageInvalidArgument() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage("Movie")
+                struct AllMovies: Reducible {
+                }
+                """,
+                expandedSource: """
+                struct AllMovies: Reducible {
+                }
+                """,
+                diagnostics: [
+                    DiagnosticSpec(message: "@Storage requires a single argument in the form 'TypeName.self'", line: 1, column: 1),
+                ],
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
 }

--- a/Tests/UDFMacrosTests/UDFMacrosTests.swift
+++ b/Tests/UDFMacrosTests/UDFMacrosTests.swift
@@ -2458,4 +2458,157 @@ final class UDFMacrosTests: XCTestCase {
             throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
+
+    /// Hand-written storage property is left untouched — macro doesn't
+    /// regenerate it even though it comes from a .hasMany relationship.
+    func testStorageRelationshipsHasManySkipsExistingProperty() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(Dish.self)
+                @StorageRelationships(
+                    .hasMany(Restaurant.self)
+                )
+                struct AllDishes: Reducible {
+                    var byRestaurantId: [Restaurant.ID: OrderedSet<Dish.ID>] = [:]
+                }
+                """,
+                expandedSource: """
+                struct AllDishes: Reducible {
+                    var byRestaurantId: [Restaurant.ID: OrderedSet<Dish.ID>] = [:]
+
+                    var byId: [Dish.ID: Dish] = [:]
+
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadItems<Dish>:
+                            byId.insert(items: action.items)
+
+                        case let action as Actions.DidLoadItem<Dish>:
+                            byId.insert(item: action.item)
+
+                        case let action as Actions.DidUpdateItem<Dish>:
+                            byId[action.item.id] = action.item
+
+                        case let action as Actions.DeleteItem<Dish>:
+                            byId.removeValue(forKey: action.item.id)
+
+                        default:
+                            reduceRelationships(action)
+                        }
+                    }
+
+                    func dishBy(id: Dish.ID) -> Dish {
+                        byId[id] ?? .empty
+                    }
+
+                    mutating func reduceRelationships(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadNestedItem<Restaurant.ID, Dish>:
+                            byId.insert(item: action.item)
+                            byRestaurantId.append(action.item.id, by: action.parentId)
+
+                        case let action as Actions.DidLoadNestedItems<Restaurant.ID, Dish>:
+                            byId.insert(items: action.items)
+                            byRestaurantId.append(action.items.ids, by: action.parentId)
+
+                        case let action as Actions.DidLoadNestedByParents<Restaurant.ID, Dish>:
+                            for (parentId, children) in action.dictionary {
+                                byId.insert(items: children)
+                                byRestaurantId.append(children.ids, by: parentId)
+                            }
+
+                        default:
+                            break
+                        }
+                    }
+
+                    func dishesBy(restaurant id: Restaurant.ID) -> [Dish.ID] {
+                        Array(byRestaurantId[id] ?? [])
+                    }
+                }
+                """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    /// Hand-written accessor is left untouched — macro doesn't regenerate it.
+    func testStorageRelationshipsHasManySkipsExistingAccessor() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(Dish.self)
+                @StorageRelationships(
+                    .hasMany(Restaurant.self)
+                )
+                struct AllDishes: Reducible {
+                    func dishesBy(restaurant id: Restaurant.ID) -> [Dish.ID] {
+                        Array(byRestaurantId[id] ?? [])
+                    }
+                }
+                """,
+                expandedSource: """
+                struct AllDishes: Reducible {
+                    func dishesBy(restaurant id: Restaurant.ID) -> [Dish.ID] {
+                        Array(byRestaurantId[id] ?? [])
+                    }
+
+                    var byId: [Dish.ID: Dish] = [:]
+
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadItems<Dish>:
+                            byId.insert(items: action.items)
+
+                        case let action as Actions.DidLoadItem<Dish>:
+                            byId.insert(item: action.item)
+
+                        case let action as Actions.DidUpdateItem<Dish>:
+                            byId[action.item.id] = action.item
+
+                        case let action as Actions.DeleteItem<Dish>:
+                            byId.removeValue(forKey: action.item.id)
+
+                        default:
+                            reduceRelationships(action)
+                        }
+                    }
+
+                    func dishBy(id: Dish.ID) -> Dish {
+                        byId[id] ?? .empty
+                    }
+
+                    var byRestaurantId: [Restaurant.ID: OrderedSet<Dish.ID>] = [:]
+
+                    mutating func reduceRelationships(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadNestedItem<Restaurant.ID, Dish>:
+                            byId.insert(item: action.item)
+                            byRestaurantId.append(action.item.id, by: action.parentId)
+
+                        case let action as Actions.DidLoadNestedItems<Restaurant.ID, Dish>:
+                            byId.insert(items: action.items)
+                            byRestaurantId.append(action.items.ids, by: action.parentId)
+
+                        case let action as Actions.DidLoadNestedByParents<Restaurant.ID, Dish>:
+                            for (parentId, children) in action.dictionary {
+                                byId.insert(items: children)
+                                byRestaurantId.append(children.ids, by: parentId)
+                            }
+
+                        default:
+                            break
+                        }
+                    }
+                }
+                """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
 }

--- a/Tests/UDFMacrosTests/UDFMacrosTests.swift
+++ b/Tests/UDFMacrosTests/UDFMacrosTests.swift
@@ -1904,7 +1904,7 @@ final class UDFMacrosTests: XCTestCase {
         #endif
     }
 
-    // MARK: - StorageRelationships Tests
+    // MARK: - StorageRelationships .hasOne Tests
 
     /// Single hasOne relationship, default name/label. Only DidLoadNestedItem is
     /// generated — bulk "by parents" loading is app-level and out of scope.
@@ -2101,7 +2101,7 @@ final class UDFMacrosTests: XCTestCase {
                 @Storage(Movie.self)
                 @StorageRelationships(
                     .hasOne(Person.self),
-                    .hasOne(Person.self)
+                    .hasMany(Personnel.self, name: "byPersonId")
                 )
                 struct AllMovies: Reducible {
                 }
@@ -2228,14 +2228,16 @@ final class UDFMacrosTests: XCTestCase {
         #endif
     }
 
-    /// .hasMany is deliberately unimplemented — a clear diagnostic, not guessed code.
-    /// Note: @Storage still generates its own members (byId/reduce/accessor)
-    /// regardless — its hasRelationships check is name-only (it can't see whether
-    /// the sibling macro actually succeeded), so `reduceRelationships(action)` is
-    /// still called in `default:` even though @StorageRelationships produced
-    /// nothing here. That's fine: the diagnostic below already fails the build,
-    /// this just documents that @Storage's own output is unaffected.
-    func testStorageRelationshipsHasManyNotYetSupported() throws {
+    // MARK: - StorageRelationships .hasMany Tests
+
+    /// Single hasMany relationship, default naming. Uses the same Dish/Restaurant
+    /// pair as the real hand-written AllDishes, so the generated output can be
+    /// diffed directly against it: default name is `byRestaurantId` (not `byMovie`
+    /// / not pluralized) — the key is still a single Restaurant.ID, only the
+    /// *value* is a collection. Three reduce cases are generated (DidLoadNestedItem,
+    /// DidLoadNestedItems, DidLoadNestedByParents), all additive via `.append`,
+    /// matching the union convention confirmed in the real AllDishes/AllReviews.
+    func testStorageRelationshipsSingleHasManyDefaultNaming() throws {
         #if canImport(UDFMacrosMacros)
             assertMacroExpansion(
                 """
@@ -2273,12 +2275,180 @@ final class UDFMacrosTests: XCTestCase {
                     func dishBy(id: Dish.ID) -> Dish {
                         byId[id] ?? .empty
                     }
+
+                    var byRestaurantId: [Restaurant.ID: OrderedSet<Dish.ID>] = [:]
+
+                    mutating func reduceRelationships(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadNestedItem<Restaurant.ID, Dish>:
+                            byId.insert(item: action.item)
+                            byRestaurantId.append(action.item.id, by: action.parentId)
+
+                        case let action as Actions.DidLoadNestedItems<Restaurant.ID, Dish>:
+                            byId.insert(items: action.items)
+                            byRestaurantId.append(action.items.ids, by: action.parentId)
+
+                        case let action as Actions.DidLoadNestedByParents<Restaurant.ID, Dish>:
+                            for (parentId, children) in action.dictionary {
+                                byId.insert(items: children)
+                                byRestaurantId.append(children.ids, by: parentId)
+                            }
+
+                        default:
+                            break
+                        }
+                    }
+
+                    func dishesBy(restaurant id: Restaurant.ID) -> [Dish.ID] {
+                        Array(byRestaurantId[id] ?? [])
+                    }
+                }
+                """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    /// hasOne and hasMany in the same @StorageRelationships call, to different
+    /// parent types — no collision, both generate correctly, ordered hasOne-first
+    /// throughout (properties, reduce cases, accessors).
+    func testStorageRelationshipsMixedHasOneAndHasMany() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(Restaurant.self)
+                @StorageRelationships(
+                    .hasOne(Review.self),
+                    .hasMany(Category.self)
+                )
+                struct AllRestaurants: Reducible {
+                }
+                """,
+                expandedSource: """
+                struct AllRestaurants: Reducible {
+
+                    var byId: [Restaurant.ID: Restaurant] = [:]
+
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadItems<Restaurant>:
+                            byId.insert(items: action.items)
+
+                        case let action as Actions.DidLoadItem<Restaurant>:
+                            byId.insert(item: action.item)
+
+                        case let action as Actions.DidUpdateItem<Restaurant>:
+                            byId[action.item.id] = action.item
+
+                        case let action as Actions.DeleteItem<Restaurant>:
+                            byId.removeValue(forKey: action.item.id)
+
+                        default:
+                            reduceRelationships(action)
+                        }
+                    }
+
+                    func restaurantBy(id: Restaurant.ID) -> Restaurant {
+                        byId[id] ?? .empty
+                    }
+
+                    var byReviewId: [Review.ID: Restaurant.ID] = [:]
+
+                    var byCategoryId: [Category.ID: OrderedSet<Restaurant.ID>] = [:]
+
+                    mutating func reduceRelationships(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadNestedItem<Review.ID, Restaurant>:
+                            byId.insert(item: action.item)
+                            byReviewId[action.parentId] = action.item.id
+
+                        case let action as Actions.DidLoadNestedItem<Category.ID, Restaurant>:
+                            byId.insert(item: action.item)
+                            byCategoryId.append(action.item.id, by: action.parentId)
+
+                        case let action as Actions.DidLoadNestedItems<Category.ID, Restaurant>:
+                            byId.insert(items: action.items)
+                            byCategoryId.append(action.items.ids, by: action.parentId)
+
+                        case let action as Actions.DidLoadNestedByParents<Category.ID, Restaurant>:
+                            for (parentId, children) in action.dictionary {
+                                byId.insert(items: children)
+                                byCategoryId.append(children.ids, by: parentId)
+                            }
+
+                        default:
+                            break
+                        }
+                    }
+
+                    func restaurantBy(review id: Review.ID) -> Restaurant.ID? {
+                        byReviewId[id]
+                    }
+
+                    func restaurantsBy(category id: Category.ID) -> [Restaurant.ID] {
+                        Array(byCategoryId[id] ?? [])
+                    }
+                }
+                """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    /// Two relationships to the same parent type — one hasOne, one hasMany with
+    /// an explicit `name:` override — must still be flagged. Storage property
+    /// names differ (`byProducerId` vs `coProducers`), so the existing
+    /// `duplicateName` check wouldn't catch this; both would otherwise generate
+    /// `Actions.DidLoadNestedItem<Producer.ID, Movie>` as a duplicate case.
+    func testStorageRelationshipsDuplicateParentTypeDiagnostic() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(Movie.self)
+                @StorageRelationships(
+                    .hasOne(Producer.self),
+                    .hasMany(Producer.self, name: "coProducers")
+                )
+                struct AllMovies: Reducible {
+                }
+                """,
+                expandedSource: """
+                struct AllMovies: Reducible {
+
+                    var byId: [Movie.ID: Movie] = [:]
+
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadItems<Movie>:
+                            byId.insert(items: action.items)
+
+                        case let action as Actions.DidLoadItem<Movie>:
+                            byId.insert(item: action.item)
+
+                        case let action as Actions.DidUpdateItem<Movie>:
+                            byId[action.item.id] = action.item
+
+                        case let action as Actions.DeleteItem<Movie>:
+                            byId.removeValue(forKey: action.item.id)
+
+                        default:
+                            reduceRelationships(action)
+                        }
+                    }
+
+                    func movieBy(id: Movie.ID) -> Movie {
+                        byId[id] ?? .empty
+                    }
                 }
                 """,
                 diagnostics: [
                     DiagnosticSpec(
-                        message: "@StorageRelationships does not generate .hasMany relationships yet — write this one by hand for now (deliberately deferred, not guessed at).",
-                        line: 3,
+                        message: "'Producer' is already used as a relationship parent type on this declaration. Two relationships to the same parent type — regardless of whether they're `.hasOne` or `.hasMany` — would generate a duplicate `Actions.DidLoadNestedItem<Producer.ID, _>` case in reduceRelationships(_:), even if their storage property names differ via `name:`.",
+                        line: 4,
                         column: 5
                     ),
                 ],

--- a/Tests/UDFMacrosTests/UDFMacrosTests.swift
+++ b/Tests/UDFMacrosTests/UDFMacrosTests.swift
@@ -1939,7 +1939,7 @@ final class UDFMacrosTests: XCTestCase {
                             byId.removeValue(forKey: action.item.id)
 
                         default:
-                            reduceRelationships(action)
+                            _reduceRelationships(action)
                         }
                     }
 
@@ -1949,7 +1949,7 @@ final class UDFMacrosTests: XCTestCase {
 
                     var byReviewId: [Review.ID: Restaurant.ID] = [:]
 
-                    mutating func reduceRelationships(_ action: some Action) {
+                    mutating func _reduceRelationships(_ action: some Action) {
                         switch action {
                         case let action as Actions.DidLoadNestedItem<Review.ID, Restaurant>:
                             byId.insert(item: action.item)
@@ -2010,7 +2010,7 @@ final class UDFMacrosTests: XCTestCase {
                             byId.removeValue(forKey: action.item.id)
 
                         default:
-                            reduceRelationships(action)
+                            _reduceRelationships(action)
                         }
                     }
 
@@ -2024,7 +2024,7 @@ final class UDFMacrosTests: XCTestCase {
 
                     var byDishId: [Dish.ID: Restaurant.ID] = [:]
 
-                    mutating func reduceRelationships(_ action: some Action) {
+                    mutating func _reduceRelationships(_ action: some Action) {
                         switch action {
                         case let action as Actions.DidLoadNestedItem<Review.ID, Restaurant>:
                             byId.insert(item: action.item)
@@ -2079,7 +2079,7 @@ final class UDFMacrosTests: XCTestCase {
                 """,
                 diagnostics: [
                     DiagnosticSpec(
-                        message: "@StorageRelationships requires @Storage(_:) on the same declaration — without it, the generated reduceRelationships(_:) is never called.",
+                        message: "@StorageRelationships requires @Storage(_:) on the same declaration — without it, the generated _reduceRelationships(_:) is never called.",
                         line: 1,
                         column: 1
                     ),
@@ -2126,7 +2126,7 @@ final class UDFMacrosTests: XCTestCase {
                             byId.removeValue(forKey: action.item.id)
 
                         default:
-                            reduceRelationships(action)
+                            _reduceRelationships(action)
                         }
                     }
 
@@ -2194,7 +2194,7 @@ final class UDFMacrosTests: XCTestCase {
                             byId.removeValue(forKey: action.item.id)
 
                         default:
-                            reduceRelationships(action)
+                            _reduceRelationships(action)
                             reduceCustom(action)
                         }
                     }
@@ -2205,7 +2205,7 @@ final class UDFMacrosTests: XCTestCase {
 
                     var byReviewId: [Review.ID: Restaurant.ID] = [:]
 
-                    mutating func reduceRelationships(_ action: some Action) {
+                    mutating func _reduceRelationships(_ action: some Action) {
                         switch action {
                         case let action as Actions.DidLoadNestedItem<Review.ID, Restaurant>:
                             byId.insert(item: action.item)
@@ -2268,7 +2268,7 @@ final class UDFMacrosTests: XCTestCase {
                             byId.removeValue(forKey: action.item.id)
 
                         default:
-                            reduceRelationships(action)
+                            _reduceRelationships(action)
                         }
                     }
 
@@ -2278,7 +2278,7 @@ final class UDFMacrosTests: XCTestCase {
 
                     var byRestaurantId: [Restaurant.ID: OrderedSet<Dish.ID>] = [:]
 
-                    mutating func reduceRelationships(_ action: some Action) {
+                    mutating func _reduceRelationships(_ action: some Action) {
                         switch action {
                         case let action as Actions.DidLoadNestedItem<Restaurant.ID, Dish>:
                             byId.insert(item: action.item)
@@ -2346,7 +2346,7 @@ final class UDFMacrosTests: XCTestCase {
                             byId.removeValue(forKey: action.item.id)
 
                         default:
-                            reduceRelationships(action)
+                            _reduceRelationships(action)
                         }
                     }
 
@@ -2358,7 +2358,7 @@ final class UDFMacrosTests: XCTestCase {
 
                     var byCategoryId: [Category.ID: OrderedSet<Restaurant.ID>] = [:]
 
-                    mutating func reduceRelationships(_ action: some Action) {
+                    mutating func _reduceRelationships(_ action: some Action) {
                         switch action {
                         case let action as Actions.DidLoadNestedItem<Review.ID, Restaurant>:
                             byId.insert(item: action.item)
@@ -2436,7 +2436,7 @@ final class UDFMacrosTests: XCTestCase {
                             byId.removeValue(forKey: action.item.id)
 
                         default:
-                            reduceRelationships(action)
+                            _reduceRelationships(action)
                         }
                     }
 
@@ -2447,7 +2447,7 @@ final class UDFMacrosTests: XCTestCase {
                 """,
                 diagnostics: [
                     DiagnosticSpec(
-                        message: "'Producer' is already used as a relationship parent type on this declaration. Two relationships to the same parent type — regardless of whether they're `.hasOne` or `.hasMany` — would generate a duplicate `Actions.DidLoadNestedItem<Producer.ID, _>` case in reduceRelationships(_:), even if their storage property names differ via `name:`.",
+                        message: "'Producer' is already used as a relationship parent type on this declaration. Two relationships to the same parent type — regardless of whether they're `.hasOne` or `.hasMany` — would generate a duplicate `Actions.DidLoadNestedItem<Producer.ID, _>` case in _reduceRelationships(_:), even if their storage property names differ via `name:`.",
                         line: 4,
                         column: 5
                     ),
@@ -2494,7 +2494,7 @@ final class UDFMacrosTests: XCTestCase {
                             byId.removeValue(forKey: action.item.id)
 
                         default:
-                            reduceRelationships(action)
+                            _reduceRelationships(action)
                         }
                     }
 
@@ -2502,7 +2502,7 @@ final class UDFMacrosTests: XCTestCase {
                         byId[id] ?? .empty
                     }
 
-                    mutating func reduceRelationships(_ action: some Action) {
+                    mutating func _reduceRelationships(_ action: some Action) {
                         switch action {
                         case let action as Actions.DidLoadNestedItem<Restaurant.ID, Dish>:
                             byId.insert(item: action.item)
@@ -2573,7 +2573,7 @@ final class UDFMacrosTests: XCTestCase {
                             byId.removeValue(forKey: action.item.id)
 
                         default:
-                            reduceRelationships(action)
+                            _reduceRelationships(action)
                         }
                     }
 
@@ -2583,7 +2583,7 @@ final class UDFMacrosTests: XCTestCase {
 
                     var byRestaurantId: [Restaurant.ID: OrderedSet<Dish.ID>] = [:]
 
-                    mutating func reduceRelationships(_ action: some Action) {
+                    mutating func _reduceRelationships(_ action: some Action) {
                         switch action {
                         case let action as Actions.DidLoadNestedItem<Restaurant.ID, Dish>:
                             byId.insert(item: action.item)

--- a/Tests/UDFMacrosTests/UDFMacrosTests.swift
+++ b/Tests/UDFMacrosTests/UDFMacrosTests.swift
@@ -12,6 +12,7 @@ import XCTest
         "AutoEquatable": AutoEquatableMacro.self,
         "AutoHashable": AutoHashableMacro.self,
         "Storage": StorageMacro.self,
+        "StorageRelationships": StorageRelationshipsMacro.self,
     ]
 #endif
 
@@ -1895,6 +1896,391 @@ final class UDFMacrosTests: XCTestCase {
                 """,
                 diagnostics: [
                     DiagnosticSpec(message: "@Storage requires a single argument in the form 'TypeName.self'", line: 1, column: 1),
+                ],
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    // MARK: - StorageRelationships Tests
+
+    /// Single hasOne relationship, default name/label. Only DidLoadNestedItem is
+    /// generated — bulk "by parents" loading is app-level and out of scope.
+    func testStorageRelationshipsSingleHasOneDefaultNaming() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(Restaurant.self)
+                @StorageRelationships(
+                    .hasOne(Review.self)
+                )
+                struct AllRestaurants: Reducible {
+                }
+                """,
+                expandedSource: """
+                struct AllRestaurants: Reducible {
+
+                    var byId: [Restaurant.ID: Restaurant] = [:]
+
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadItems<Restaurant>:
+                            byId.insert(items: action.items)
+
+                        case let action as Actions.DidLoadItem<Restaurant>:
+                            byId.insert(item: action.item)
+
+                        case let action as Actions.DidUpdateItem<Restaurant>:
+                            byId[action.item.id] = action.item
+
+                        case let action as Actions.DeleteItem<Restaurant>:
+                            byId.removeValue(forKey: action.item.id)
+
+                        default:
+                            reduceRelationships(action)
+                        }
+                    }
+
+                    func restaurantBy(id: Restaurant.ID) -> Restaurant {
+                        byId[id] ?? .empty
+                    }
+
+                    var byReviewId: [Review.ID: Restaurant.ID] = [:]
+
+                    mutating func reduceRelationships(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadNestedItem<Review.ID, Restaurant>:
+                            byId.insert(item: action.item)
+                            byReviewId[action.parentId] = action.item.id
+
+                        default:
+                            break
+                        }
+                    }
+
+                    func restaurantBy(review id: Review.ID) -> Restaurant.ID? {
+                        byReviewId[id]
+                    }
+                }
+                """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    /// Three relationships in one call. Note: to match the *exact* existing
+    /// AllRestaurants naming (`byFortuneResultId`, not the default
+    /// `byFortuneWheelResultId`), `name:` is passed alongside `label:` — they're
+    /// independent overrides, and `label:` alone only changes the accessor's
+    /// argument label, not the storage property name.
+    func testStorageRelationshipsMultipleWithLabelOverrides() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(Restaurant.self)
+                @StorageRelationships(
+                    .hasOne(Review.self),
+                    .hasOne(FortuneWheelResult.self, name: "byFortuneResultId", label: "fortuneResult"),
+                    .hasOne(Dish.self, label: "dishID")
+                )
+                struct AllRestaurants: Reducible {
+                }
+                """,
+                expandedSource: """
+                struct AllRestaurants: Reducible {
+
+                    var byId: [Restaurant.ID: Restaurant] = [:]
+
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadItems<Restaurant>:
+                            byId.insert(items: action.items)
+
+                        case let action as Actions.DidLoadItem<Restaurant>:
+                            byId.insert(item: action.item)
+
+                        case let action as Actions.DidUpdateItem<Restaurant>:
+                            byId[action.item.id] = action.item
+
+                        case let action as Actions.DeleteItem<Restaurant>:
+                            byId.removeValue(forKey: action.item.id)
+
+                        default:
+                            reduceRelationships(action)
+                        }
+                    }
+
+                    func restaurantBy(id: Restaurant.ID) -> Restaurant {
+                        byId[id] ?? .empty
+                    }
+
+                    var byReviewId: [Review.ID: Restaurant.ID] = [:]
+
+                    var byFortuneResultId: [FortuneWheelResult.ID: Restaurant.ID] = [:]
+
+                    var byDishId: [Dish.ID: Restaurant.ID] = [:]
+
+                    mutating func reduceRelationships(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadNestedItem<Review.ID, Restaurant>:
+                            byId.insert(item: action.item)
+                            byReviewId[action.parentId] = action.item.id
+
+                        case let action as Actions.DidLoadNestedItem<FortuneWheelResult.ID, Restaurant>:
+                            byId.insert(item: action.item)
+                            byFortuneResultId[action.parentId] = action.item.id
+
+                        case let action as Actions.DidLoadNestedItem<Dish.ID, Restaurant>:
+                            byId.insert(item: action.item)
+                            byDishId[action.parentId] = action.item.id
+
+                        default:
+                            break
+                        }
+                    }
+
+                    func restaurantBy(review id: Review.ID) -> Restaurant.ID? {
+                        byReviewId[id]
+                    }
+
+                    func restaurantBy(fortuneResult id: FortuneWheelResult.ID) -> Restaurant.ID? {
+                        byFortuneResultId[id]
+                    }
+
+                    func restaurantBy(dishID id: Dish.ID) -> Restaurant.ID? {
+                        byDishId[id]
+                    }
+                }
+                """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    /// @StorageRelationships without @Storage on the same declaration is a
+    /// compile-time error, not a silently-inert reduceRelationships(_:).
+    func testStorageRelationshipsRequiresStorage() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @StorageRelationships(.hasOne(Review.self))
+                struct AllRestaurants: Reducible {
+                }
+                """,
+                expandedSource: """
+                struct AllRestaurants: Reducible {
+                }
+                """,
+                diagnostics: [
+                    DiagnosticSpec(
+                        message: "@StorageRelationships requires @Storage(_:) on the same declaration — without it, the generated reduceRelationships(_:) is never called.",
+                        line: 1,
+                        column: 1
+                    ),
+                ],
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    /// Two relationships to the same parent type without an explicit `name:`
+    /// collide on the default `by<Parent>Id` name — must be a diagnostic, not a
+    /// silent duplicate declaration.
+    func testStorageRelationshipsDuplicateNameDiagnostic() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(Movie.self)
+                @StorageRelationships(
+                    .hasOne(Person.self),
+                    .hasOne(Person.self)
+                )
+                struct AllMovies: Reducible {
+                }
+                """,
+                expandedSource: """
+                struct AllMovies: Reducible {
+
+                    var byId: [Movie.ID: Movie] = [:]
+
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadItems<Movie>:
+                            byId.insert(items: action.items)
+
+                        case let action as Actions.DidLoadItem<Movie>:
+                            byId.insert(item: action.item)
+
+                        case let action as Actions.DidUpdateItem<Movie>:
+                            byId[action.item.id] = action.item
+
+                        case let action as Actions.DeleteItem<Movie>:
+                            byId.removeValue(forKey: action.item.id)
+
+                        default:
+                            reduceRelationships(action)
+                        }
+                    }
+
+                    func movieBy(id: Movie.ID) -> Movie {
+                        byId[id] ?? .empty
+                    }
+                }
+                """,
+                diagnostics: [
+                    DiagnosticSpec(message: "Relationship name 'byPersonId' is used more than once. Pass an explicit `name:` to disambiguate two relationships to the same parent type.", line: 4, column: 5),
+                ],
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    /// Both reduceRelationships(_:) and a user-written reduceCustom(_:) fire from
+    /// default: — not exclusive-or.
+    func testStorageWiresBothRelationshipsAndReduceCustom() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(Restaurant.self)
+                @StorageRelationships(
+                    .hasOne(Review.self)
+                )
+                struct AllRestaurants: Reducible {
+                    mutating func reduceCustom(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidDeleteRestaurantFromCollection:
+                            byId[action.restaurantID]?.isCollectedByCurrentUser = action.isContainedInOtherCollections
+                        default:
+                            break
+                        }
+                    }
+                }
+                """,
+                expandedSource: """
+                struct AllRestaurants: Reducible {
+                    mutating func reduceCustom(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidDeleteRestaurantFromCollection:
+                            byId[action.restaurantID]?.isCollectedByCurrentUser = action.isContainedInOtherCollections
+                        default:
+                            break
+                        }
+                    }
+
+                    var byId: [Restaurant.ID: Restaurant] = [:]
+
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadItems<Restaurant>:
+                            byId.insert(items: action.items)
+
+                        case let action as Actions.DidLoadItem<Restaurant>:
+                            byId.insert(item: action.item)
+
+                        case let action as Actions.DidUpdateItem<Restaurant>:
+                            byId[action.item.id] = action.item
+
+                        case let action as Actions.DeleteItem<Restaurant>:
+                            byId.removeValue(forKey: action.item.id)
+
+                        default:
+                            reduceRelationships(action)
+                            reduceCustom(action)
+                        }
+                    }
+
+                    func restaurantBy(id: Restaurant.ID) -> Restaurant {
+                        byId[id] ?? .empty
+                    }
+
+                    var byReviewId: [Review.ID: Restaurant.ID] = [:]
+
+                    mutating func reduceRelationships(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadNestedItem<Review.ID, Restaurant>:
+                            byId.insert(item: action.item)
+                            byReviewId[action.parentId] = action.item.id
+
+                        default:
+                            break
+                        }
+                    }
+
+                    func restaurantBy(review id: Review.ID) -> Restaurant.ID? {
+                        byReviewId[id]
+                    }
+                }
+                """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    /// .hasMany is deliberately unimplemented — a clear diagnostic, not guessed code.
+    /// Note: @Storage still generates its own members (byId/reduce/accessor)
+    /// regardless — its hasRelationships check is name-only (it can't see whether
+    /// the sibling macro actually succeeded), so `reduceRelationships(action)` is
+    /// still called in `default:` even though @StorageRelationships produced
+    /// nothing here. That's fine: the diagnostic below already fails the build,
+    /// this just documents that @Storage's own output is unaffected.
+    func testStorageRelationshipsHasManyNotYetSupported() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(Dish.self)
+                @StorageRelationships(
+                    .hasMany(Restaurant.self)
+                )
+                struct AllDishes: Reducible {
+                }
+                """,
+                expandedSource: """
+                struct AllDishes: Reducible {
+
+                    var byId: [Dish.ID: Dish] = [:]
+
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadItems<Dish>:
+                            byId.insert(items: action.items)
+
+                        case let action as Actions.DidLoadItem<Dish>:
+                            byId.insert(item: action.item)
+
+                        case let action as Actions.DidUpdateItem<Dish>:
+                            byId[action.item.id] = action.item
+
+                        case let action as Actions.DeleteItem<Dish>:
+                            byId.removeValue(forKey: action.item.id)
+
+                        default:
+                            reduceRelationships(action)
+                        }
+                    }
+
+                    func dishBy(id: Dish.ID) -> Dish {
+                        byId[id] ?? .empty
+                    }
+                }
+                """,
+                diagnostics: [
+                    DiagnosticSpec(
+                        message: "@StorageRelationships does not generate .hasMany relationships yet — write this one by hand for now (deliberately deferred, not guessed at).",
+                        line: 3,
+                        column: 5
+                    ),
                 ],
                 macros: testMacros
             )

--- a/Tests/UDFMacrosTests/UDFMacrosTests.swift
+++ b/Tests/UDFMacrosTests/UDFMacrosTests.swift
@@ -1694,6 +1694,114 @@ final class UDFMacrosTests: XCTestCase {
         #endif
     }
 
+    /// If the struct declares `reduceCustom`, the generated `reduce`'s
+    /// `default:` delegates to it instead of `break`.
+    func testStorageWiresReduceCustomWhenDeclared() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(Dish.self)
+                struct AllDishes: Reducible {
+                    mutating func reduceCustom(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidDislikeDish:
+                            byId[action.dishID]?.isLiked = false
+                        default:
+                            break
+                        }
+                    }
+                }
+                """,
+                expandedSource: """
+                struct AllDishes: Reducible {
+                    mutating func reduceCustom(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidDislikeDish:
+                            byId[action.dishID]?.isLiked = false
+                        default:
+                            break
+                        }
+                    }
+
+                    var byId: [Dish.ID: Dish] = [:]
+
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadItems<Dish>:
+                            byId.insert(items: action.items)
+
+                        case let action as Actions.DidLoadItem<Dish>:
+                            byId.insert(item: action.item)
+
+                        case let action as Actions.DidUpdateItem<Dish>:
+                            byId[action.item.id] = action.item
+
+                        case let action as Actions.DeleteItem<Dish>:
+                            byId.removeValue(forKey: action.item.id)
+
+                        default:
+                            reduceCustom(action)
+                        }
+                    }
+
+                    func dishBy(id: Dish.ID) -> Dish {
+                        byId[id] ?? .empty
+                    }
+                }
+                """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    /// Without a declared `reduceCustom`, `default:` stays `break` exactly
+    /// as before — no behavior change for storages that don't need a hook.
+    func testStorageDefaultCaseStaysBreakWithoutReduceCustom() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(Dish.self)
+                struct AllDishes: Reducible {
+                }
+                """,
+                expandedSource: """
+                struct AllDishes: Reducible {
+
+                    var byId: [Dish.ID: Dish] = [:]
+
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadItems<Dish>:
+                            byId.insert(items: action.items)
+
+                        case let action as Actions.DidLoadItem<Dish>:
+                            byId.insert(item: action.item)
+
+                        case let action as Actions.DidUpdateItem<Dish>:
+                            byId[action.item.id] = action.item
+
+                        case let action as Actions.DeleteItem<Dish>:
+                            byId.removeValue(forKey: action.item.id)
+
+                        default:
+                            break
+                        }
+                    }
+
+                    func dishBy(id: Dish.ID) -> Dish {
+                        byId[id] ?? .empty
+                    }
+                }
+                """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
     func testStorageRequiresStruct() throws {
         #if canImport(UDFMacrosMacros)
             assertMacroExpansion(

--- a/Tests/UDFMacrosTests/UDFMacrosTests.swift
+++ b/Tests/UDFMacrosTests/UDFMacrosTests.swift
@@ -48,12 +48,12 @@ final class UDFMacrosTests: XCTestCase {
                 extension TestEnum: Equatable {
                     static func ==(lhs: TestEnum, rhs: TestEnum) -> Bool {
                         switch (lhs, rhs) {
-                        case let (.congratulations(lhs0), .congratulations(rhs0)):
-                            lhs0 == rhs0
+                        case let (.congratulations(_), .congratulations(_)):
+                            true
                         case let (.analytics(lhs0), .analytics(rhs0)):
                             lhs0 == rhs0
-                        case let (.addVideoFeedback(lhs0), .addVideoFeedback(rhs0)):
-                            lhs0 == rhs0
+                        case let (.addVideoFeedback(_), .addVideoFeedback(_)):
+                            true
                         case let (.addPhotoFeedback(lhs0), .addPhotoFeedback(rhs0)):
                             lhs0 == rhs0
                         case let (.additionalPhotosZoomed(lhs0, lhs1), .additionalPhotosZoomed(rhs0, rhs1)):
@@ -253,8 +253,8 @@ final class UDFMacrosTests: XCTestCase {
                             lhs0 == rhs0
                         case let (.withTuple(lhs0), .withTuple(rhs0)):
                             lhs0 == rhs0
-                        case let (.withMixed(lhs0, lhs1, lhs2), .withMixed(rhs0, rhs1, rhs2)):
-                            lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2
+                        case let (.withMixed(lhs0, _, lhs2), .withMixed(rhs0, _, rhs2)):
+                            lhs0 == rhs0 && lhs2 == rhs2
                         case let (.withUUID(lhs0, lhs1), .withUUID(rhs0, rhs1)):
                             lhs0 == rhs0 && lhs1 == rhs1
                         default:
@@ -1513,6 +1513,8 @@ final class UDFMacrosTests: XCTestCase {
         #endif
     }
 
+    // MARK: - Storage Tests
+
     func testStorageBasicExpansion() throws {
         #if canImport(UDFMacrosMacros)
             assertMacroExpansion(
@@ -1684,6 +1686,61 @@ final class UDFMacrosTests: XCTestCase {
                         default:
                             break
                         }
+                    }
+                }
+                """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    /// Regression test: an existing overload with a DIFFERENT label
+    /// (`restaurantBy(review:)`) must not be mistaken for the macro's own
+    /// `restaurantBy(id:)` — matching on bare function name previously
+    /// caused the macro to silently skip generating `restaurantBy(id:)`
+    /// whenever any other `restaurantBy(...)` overload already existed.
+    func testStorageGeneratesAccessorDespiteDifferentlyLabeledOverload() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(Restaurant.self)
+                struct AllRestaurants: Reducible {
+                    func restaurantBy(review id: Review.ID) -> Restaurant.ID? {
+                        byReviewId[id]
+                    }
+                }
+                """,
+                expandedSource: """
+                struct AllRestaurants: Reducible {
+                    func restaurantBy(review id: Review.ID) -> Restaurant.ID? {
+                        byReviewId[id]
+                    }
+
+                    var byId: [Restaurant.ID: Restaurant] = [:]
+
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadItems<Restaurant>:
+                            byId.insert(items: action.items)
+
+                        case let action as Actions.DidLoadItem<Restaurant>:
+                            byId.insert(item: action.item)
+
+                        case let action as Actions.DidUpdateItem<Restaurant>:
+                            byId[action.item.id] = action.item
+
+                        case let action as Actions.DeleteItem<Restaurant>:
+                            byId.removeValue(forKey: action.item.id)
+
+                        default:
+                            break
+                        }
+                    }
+
+                    func restaurantBy(id: Restaurant.ID) -> Restaurant {
+                        byId[id] ?? .empty
                     }
                 }
                 """,

--- a/Tests/UDFMacrosTests/UDFMacrosTests.swift
+++ b/Tests/UDFMacrosTests/UDFMacrosTests.swift
@@ -1906,8 +1906,8 @@ final class UDFMacrosTests: XCTestCase {
 
     // MARK: - StorageRelationships Tests
 
-    /// Single hasOne relationship, default name/label. Only DidLoadNestedItem is
-    /// generated — bulk "by parents" loading is app-level and out of scope.
+    /// Single hasOne relationship, default name/label (bulk-load rationale is
+    /// documented on the `StorageRelationships` macro itself).
     func testStorageRelationshipsSingleHasOneDefaultNaming() throws {
         #if canImport(UDFMacrosMacros)
             assertMacroExpansion(
@@ -2228,13 +2228,10 @@ final class UDFMacrosTests: XCTestCase {
         #endif
     }
 
-    /// .hasMany is deliberately unimplemented — a clear diagnostic, not guessed code.
-    /// Note: @Storage still generates its own members (byId/reduce/accessor)
-    /// regardless — its hasRelationships check is name-only (it can't see whether
-    /// the sibling macro actually succeeded), so `reduceRelationships(action)` is
-    /// still called in `default:` even though @StorageRelationships produced
-    /// nothing here. That's fine: the diagnostic below already fails the build,
-    /// this just documents that @Storage's own output is unaffected.
+    /// .hasMany is deliberately unimplemented — a clear diagnostic, not guessed
+    /// code. @Storage still generates its own members regardless (its
+    /// hasRelationships check is name-only) — harmless since the diagnostic
+    /// below already fails the build.
     func testStorageRelationshipsHasManyNotYetSupported() throws {
         #if canImport(UDFMacrosMacros)
             assertMacroExpansion(

--- a/Tests/UDFMacrosTests/UDFMacrosTests.swift
+++ b/Tests/UDFMacrosTests/UDFMacrosTests.swift
@@ -2294,6 +2294,10 @@ final class UDFMacrosTests: XCTestCase {
                                 byRestaurantId.append(children.ids, by: parentId)
                             }
 
+                        case let action as Actions.DeleteNestedItem<Restaurant.ID, Dish>:
+                            byId.removeValue(forKey: action.item.id)
+                            byRestaurantId[action.parentId]?.remove(action.item.id)
+
                         default:
                             break
                         }
@@ -2377,6 +2381,10 @@ final class UDFMacrosTests: XCTestCase {
                                 byId.insert(items: children)
                                 byCategoryId.append(children.ids, by: parentId)
                             }
+
+                        case let action as Actions.DeleteNestedItem<Category.ID, Restaurant>:
+                            byId.removeValue(forKey: action.item.id)
+                            byCategoryId[action.parentId]?.remove(action.item.id)
 
                         default:
                             break
@@ -2518,6 +2526,10 @@ final class UDFMacrosTests: XCTestCase {
                                 byRestaurantId.append(children.ids, by: parentId)
                             }
 
+                        case let action as Actions.DeleteNestedItem<Restaurant.ID, Dish>:
+                            byId.removeValue(forKey: action.item.id)
+                            byRestaurantId[action.parentId]?.remove(action.item.id)
+
                         default:
                             break
                         }
@@ -2599,9 +2611,95 @@ final class UDFMacrosTests: XCTestCase {
                                 byRestaurantId.append(children.ids, by: parentId)
                             }
 
+                        case let action as Actions.DeleteNestedItem<Restaurant.ID, Dish>:
+                            byId.removeValue(forKey: action.item.id)
+                            byRestaurantId[action.parentId]?.remove(action.item.id)
+
                         default:
                             break
                         }
+                    }
+                }
+                """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    /// DeleteNestedItem for hasMany — full-item form only, matching the
+    /// confirmed AllLabels.swift precedent. Removes the item from byId and from
+    /// the OrderedSet under its parent, mirroring the .remove(_:) pattern seen
+    /// in every real DeleteNestedItem usage in Librarius/Wain/FlatPlanet.
+    func testStorageRelationshipsHasManyDeleteNestedItem() throws {
+        #if canImport(UDFMacrosMacros)
+            assertMacroExpansion(
+                """
+                @Storage(Dish.self)
+                @StorageRelationships(
+                    .hasMany(Restaurant.self)
+                )
+                struct AllDishes: Reducible {
+                }
+                """,
+                expandedSource: """
+                struct AllDishes: Reducible {
+
+                    var byId: [Dish.ID: Dish] = [:]
+
+                    mutating func reduce(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadItems<Dish>:
+                            byId.insert(items: action.items)
+
+                        case let action as Actions.DidLoadItem<Dish>:
+                            byId.insert(item: action.item)
+
+                        case let action as Actions.DidUpdateItem<Dish>:
+                            byId[action.item.id] = action.item
+
+                        case let action as Actions.DeleteItem<Dish>:
+                            byId.removeValue(forKey: action.item.id)
+
+                        default:
+                            _reduceRelationships(action)
+                        }
+                    }
+
+                    func dishBy(id: Dish.ID) -> Dish {
+                        byId[id] ?? .empty
+                    }
+
+                    var byRestaurantId: [Restaurant.ID: OrderedSet<Dish.ID>] = [:]
+
+                    mutating func _reduceRelationships(_ action: some Action) {
+                        switch action {
+                        case let action as Actions.DidLoadNestedItem<Restaurant.ID, Dish>:
+                            byId.insert(item: action.item)
+                            byRestaurantId.append(action.item.id, by: action.parentId)
+
+                        case let action as Actions.DidLoadNestedItems<Restaurant.ID, Dish>:
+                            byId.insert(items: action.items)
+                            byRestaurantId.append(action.items.ids, by: action.parentId)
+
+                        case let action as Actions.DidLoadNestedByParents<Restaurant.ID, Dish>:
+                            for (parentId, children) in action.dictionary {
+                                byId.insert(items: children)
+                                byRestaurantId.append(children.ids, by: parentId)
+                            }
+
+                        case let action as Actions.DeleteNestedItem<Restaurant.ID, Dish>:
+                            byId.removeValue(forKey: action.item.id)
+                            byRestaurantId[action.parentId]?.remove(action.item.id)
+
+                        default:
+                            break
+                        }
+                    }
+
+                    func dishesBy(restaurant id: Restaurant.ID) -> [Dish.ID] {
+                        Array(byRestaurantId[id] ?? [])
                     }
                 }
                 """,

--- a/Tests/UDFMacrosTests/UDFMacrosTests.swift
+++ b/Tests/UDFMacrosTests/UDFMacrosTests.swift
@@ -1939,7 +1939,7 @@ final class UDFMacrosTests: XCTestCase {
                             byId.removeValue(forKey: action.item.id)
 
                         default:
-                            reduceRelationships(action)
+                            _reduceRelationships(action)
                         }
                     }
 
@@ -1949,7 +1949,7 @@ final class UDFMacrosTests: XCTestCase {
 
                     var byReviewId: [Review.ID: Restaurant.ID] = [:]
 
-                    mutating func reduceRelationships(_ action: some Action) {
+                    mutating func _reduceRelationships(_ action: some Action) {
                         switch action {
                         case let action as Actions.DidLoadNestedItem<Review.ID, Restaurant>:
                             byId.insert(item: action.item)
@@ -2010,7 +2010,7 @@ final class UDFMacrosTests: XCTestCase {
                             byId.removeValue(forKey: action.item.id)
 
                         default:
-                            reduceRelationships(action)
+                            _reduceRelationships(action)
                         }
                     }
 
@@ -2024,7 +2024,7 @@ final class UDFMacrosTests: XCTestCase {
 
                     var byDishId: [Dish.ID: Restaurant.ID] = [:]
 
-                    mutating func reduceRelationships(_ action: some Action) {
+                    mutating func _reduceRelationships(_ action: some Action) {
                         switch action {
                         case let action as Actions.DidLoadNestedItem<Review.ID, Restaurant>:
                             byId.insert(item: action.item)
@@ -2064,7 +2064,7 @@ final class UDFMacrosTests: XCTestCase {
     }
 
     /// @StorageRelationships without @Storage on the same declaration is a
-    /// compile-time error, not a silently-inert reduceRelationships(_:).
+    /// compile-time error, not a silently-inert _reduceRelationships(_:).
     func testStorageRelationshipsRequiresStorage() throws {
         #if canImport(UDFMacrosMacros)
             assertMacroExpansion(
@@ -2079,7 +2079,7 @@ final class UDFMacrosTests: XCTestCase {
                 """,
                 diagnostics: [
                     DiagnosticSpec(
-                        message: "@StorageRelationships requires @Storage(_:) on the same declaration — without it, the generated reduceRelationships(_:) is never called.",
+                        message: "@StorageRelationships requires @Storage(_:) on the same declaration — without it, the generated _reduceRelationships(_:) is never called.",
                         line: 1,
                         column: 1
                     ),
@@ -2126,7 +2126,7 @@ final class UDFMacrosTests: XCTestCase {
                             byId.removeValue(forKey: action.item.id)
 
                         default:
-                            reduceRelationships(action)
+                            _reduceRelationships(action)
                         }
                     }
 
@@ -2145,7 +2145,7 @@ final class UDFMacrosTests: XCTestCase {
         #endif
     }
 
-    /// Both reduceRelationships(_:) and a user-written reduceCustom(_:) fire from
+    /// Both _reduceRelationships(_:) and a user-written reduceCustom(_:) fire from
     /// default: — not exclusive-or.
     func testStorageWiresBothRelationshipsAndReduceCustom() throws {
         #if canImport(UDFMacrosMacros)
@@ -2194,7 +2194,7 @@ final class UDFMacrosTests: XCTestCase {
                             byId.removeValue(forKey: action.item.id)
 
                         default:
-                            reduceRelationships(action)
+                            _reduceRelationships(action)
                             reduceCustom(action)
                         }
                     }
@@ -2205,7 +2205,7 @@ final class UDFMacrosTests: XCTestCase {
 
                     var byReviewId: [Review.ID: Restaurant.ID] = [:]
 
-                    mutating func reduceRelationships(_ action: some Action) {
+                    mutating func _reduceRelationships(_ action: some Action) {
                         switch action {
                         case let action as Actions.DidLoadNestedItem<Review.ID, Restaurant>:
                             byId.insert(item: action.item)
@@ -2263,7 +2263,7 @@ final class UDFMacrosTests: XCTestCase {
                             byId.removeValue(forKey: action.item.id)
 
                         default:
-                            reduceRelationships(action)
+                            _reduceRelationships(action)
                         }
                     }
 


### PR DESCRIPTION
## `@StorageRelationships` macro: adds `hasMany` relationship support alongside `hasOne`

### What it does

Extends `@StorageRelationships(...)` — previously `hasOne`-only — to also generate the boilerplate for `hasMany` relationships on a `Reducible` storage already using `@Storage`. Given:

    @Storage(Review.self)
    @StorageRelationships(
        .hasMany(Restaurant.self)
    )
    struct AllReviews: Reducible {
        func reviewBy(id: Review.ID) -> Review { byId[id] ?? .empty }
        func reviewBy(restaurantID: Restaurant.ID) -> [Review.ID] { Array(byRestaurantId[restaurantID] ?? []) }
    }

It generates, per `hasMany` relationship:
- `var by<Parent>Id: [Parent.ID: OrderedSet<Item.ID>] = [:]` — same `by<Parent>Id` naming as `hasOne`; no pluralization on the property, since the key is still a single `Parent.ID` and only the value is a collection
- three `reduceRelationships(_:)` cases, all additive via `.append(_:by:)`, never a direct assignment: `Actions.DidLoadNestedItem<Parent.ID, Item>`, `Actions.DidLoadNestedItems<Parent.ID, Item>`, and `Actions.DidLoadNestedByParents<Parent.ID, Item>`
- a pluralized accessor overload `<item>sBy(<label>: Parent.ID) -> [Item.ID]`

`hasOne` relationships are untouched and continue to work exactly as before; both kinds can be mixed in the same `@StorageRelationships(...)` call.

### Why `.append`, not a direct assignment

Checked against the real hand-written `AllDishes`/`AllReviews` before writing any generation code: every existing nested relationship case there (`DidLoadNestedItem`, `DidLoadNestedItems`) uses `.append(_:by:)`, never overwrites the dictionary entry directly. `hasMany` generation follows the same convention.

### New diagnostic: duplicate parent type across relationship kinds

Two relationships to the same parent type — one `hasOne` and one `hasMany`, or any combination — generate the same `Actions.DidLoadNestedItem<Parent.ID, Item>` case regardless of kind, which is a duplicate-case compile error even if their storage property names differ via `name:`. The existing duplicate-name diagnostic only catches collisions on the storage property name, so it doesn't cover this. Added a separate check that tracks parent type names across both `hasOne` and `hasMany` in the same call.

(This also surfaced that the previous duplicate-name test was exercising an invalid premise — two `hasOne` relationships to the same parent type, which the new parent-type check now catches first. That test was rewritten to isolate a genuine name-only collision instead.)

### Bulk load is generated for `hasMany`, not `hasOne`

The existing `hasOne` behavior — no bulk "load nested items grouped by parent" — is unchanged and for the same reason as before (app-level action, not standardized across apps). For `hasMany`, the equivalent case (`Actions.DidLoadNestedByParents`) *is* generated, since batch-loading children for several parents at once is the common case for one-to-many data, unlike one-to-one. The public doc comment on `@StorageRelationships` now documents both cases explicitly instead of one blanket statement covering only `hasOne`.

### Behavioral verification

Beyond `assertMacroExpansion` unit tests, verified behavioral equivalence on `AllReviews` against real staging data — temporarily added matching `print` statements to both the hand-written version and the macro-generated version 